### PR TITLE
Omdøp klasser for forespurt data

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiver.kt
@@ -6,9 +6,9 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Periode
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.PriProducer
@@ -58,7 +58,7 @@ class LagreBegrensetForespoerselRiver(
         skjaeringstidspunkt = null,
         sykmeldingsperioder = Spleis.Key.SYKMELDINGSPERIODER.fra(packet).fromJson(Periode.serializer().list()),
         egenmeldingsperioder = emptyList(),
-        forespurtData = Spleis.Key.FORESPURT_DATA.fra(packet).fromJson(ForespurtDataDto.serializer().list()),
+        forespurtData = Spleis.Key.FORESPURT_DATA.fra(packet).fromJson(SpleisForespurtDataDto.serializer().list()),
         forespoerselBesvart = null,
         status = Status.AKTIV,
         type = Type.BEGRENSET,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
@@ -6,9 +6,9 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Periode
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.PriProducer
@@ -66,7 +66,7 @@ class LagreKomplettForespoerselRiver(
             skjaeringstidspunkt = Spleis.Key.SKJÆRINGSTIDSPUNKT.fra(packet).fromJson(LocalDateSerializer),
             sykmeldingsperioder = Spleis.Key.SYKMELDINGSPERIODER.fra(packet).fromJson(Periode.serializer().list()),
             egenmeldingsperioder = Spleis.Key.EGENMELDINGSPERIODER.fra(packet).fromJson(Periode.serializer().list()),
-            forespurtData = Spleis.Key.FORESPURT_DATA.fra(packet).fromJson(ForespurtDataDto.serializer().list()),
+            forespurtData = Spleis.Key.FORESPURT_DATA.fra(packet).fromJson(SpleisForespurtDataDto.serializer().list()),
             forespoerselBesvart = null,
             status = Status.AKTIV,
             type = Type.KOMPLETT,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
@@ -67,6 +67,7 @@ class TilgjengeliggjoerForespoerselRiver(
         )
             .let {
                 val forespoersel = forespoerselDao.hentAktivForespoerselFor(it.forespoerselId)
+
                 if (forespoersel != null) {
                     loggernaut.aapen.info("Forespørsel funnet.")
                     it.copy(resultat = ForespoerselSvar.Suksess(forespoersel))

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
@@ -4,9 +4,9 @@ import kotliquery.Row
 import kotliquery.TransactionalSession
 import kotliquery.sessionOf
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Periode
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.execute
@@ -41,7 +41,7 @@ class ForespoerselDao(private val dataSource: DataSource) {
         val jsonFelter = mapOf(
             Db.SYKMELDINGSPERIODER to forespoersel.sykmeldingsperioder.toJsonStr(Periode.serializer().list()),
             Db.EGENMELDINGSPERIODER to forespoersel.egenmeldingsperioder.toJsonStr(Periode.serializer().list()),
-            Db.FORESPURT_DATA to forespoersel.forespurtData.toJsonStr(ForespurtDataDto.serializer().list())
+            Db.FORESPURT_DATA to forespoersel.forespurtData.toJsonStr(SpleisForespurtDataDto.serializer().list())
         )
 
         val kolonnenavn = (felter + jsonFelter).keys.joinToString()
@@ -129,7 +129,7 @@ fun Row.toForespoerselDto(): ForespoerselDto =
         sykmeldingsperioder = Db.SYKMELDINGSPERIODER.let(::string).fromJson(Periode.serializer().list()),
         egenmeldingsperioder = Db.EGENMELDINGSPERIODER.let(::string).fromJson(Periode.serializer().list()),
         skjaeringstidspunkt = Db.SKJAERINGSTIDSPUNKT.let(::localDateOrNull),
-        forespurtData = Db.FORESPURT_DATA.let(::string).fromJson(ForespurtDataDto.serializer().list()),
+        forespurtData = Db.FORESPURT_DATA.let(::string).fromJson(SpleisForespurtDataDto.serializer().list()),
         forespoerselBesvart = Db.FORESPOERSEL_BESVART.let(::localDateTimeOrNull),
         status = Db.STATUS.let(::string).let(Status::valueOf),
         type = Db.TYPE.let(::string).let(Type::valueOf),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
@@ -18,7 +18,7 @@ data class ForespoerselDto(
     val skjaeringstidspunkt: LocalDate?,
     val sykmeldingsperioder: List<Periode>,
     val egenmeldingsperioder: List<Periode>,
-    val forespurtData: List<ForespurtDataDto>,
+    val forespurtData: List<SpleisForespurtDataDto>,
     val forespoerselBesvart: LocalDateTime?,
     val status: Status,
     val dokumentId: UUID?,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvar.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvar.kt
@@ -26,7 +26,7 @@ data class ForespoerselSvar(
         val fnr: String,
         val sykmeldingsperioder: List<Periode>,
         val egenmeldingsperioder: List<Periode>,
-        val forespurtData: List<ForespurtDataDto>
+        val forespurtData: List<SpleisForespurtDataDto>
     ) {
         constructor(forespoersel: ForespoerselDto) : this(
             orgnr = forespoersel.orgnr,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/SpleisForespurtDataDto.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/SpleisForespurtDataDto.kt
@@ -15,31 +15,31 @@ import java.time.YearMonth
 @Serializable
 @OptIn(ExperimentalSerializationApi::class)
 @JsonClassDiscriminator("opplysningstype")
-sealed class ForespurtDataDto
+sealed class SpleisForespurtDataDto
 
 @Serializable
 @SerialName("Arbeidsgiverperiode")
-object ArbeidsgiverPeriode : ForespurtDataDto()
+object SpleisArbeidsgiverperiode : SpleisForespurtDataDto()
 
 @Serializable
 @SerialName("Inntekt")
-data class Inntekt(val forslag: ForslagInntekt) : ForespurtDataDto()
+data class SpleisInntekt(val forslag: SpleisForslagInntekt) : SpleisForespurtDataDto()
 
 @Serializable
 @SerialName("FastsattInntekt")
-data class FastsattInntekt(val fastsattInntekt: Double) : ForespurtDataDto()
+data class SpleisFastsattInntekt(val fastsattInntekt: Double) : SpleisForespurtDataDto()
 
 @Serializable
 @SerialName("Refusjon")
-data class Refusjon(val forslag: List<ForslagRefusjon>) : ForespurtDataDto()
+data class SpleisRefusjon(val forslag: List<SpleisForslagRefusjon>) : SpleisForespurtDataDto()
 
 @Serializable
-data class ForslagInntekt(
+data class SpleisForslagInntekt(
     val beregningsmåneder: List<YearMonth>
 )
 
 @Serializable
-data class ForslagRefusjon(
+data class SpleisForslagRefusjon(
     val fom: LocalDate,
     val tom: LocalDate?,
     val beløp: Double

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiverTest.kt
@@ -15,9 +15,9 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.Env.fromEnv
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselMottatt
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Periode
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.PriProducer
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.spleis.Spleis
@@ -47,7 +47,7 @@ class LagreBegrensetForespoerselRiverTest : FunSpec({
             Spleis.Key.FØDSELSNUMMER to forespoersel.fnr.toJson(),
             Spleis.Key.VEDTAKSPERIODE_ID to forespoersel.vedtaksperiodeId.toJson(),
             Spleis.Key.SYKMELDINGSPERIODER to forespoersel.sykmeldingsperioder.toJson(Periode.serializer().list()),
-            Spleis.Key.FORESPURT_DATA to forespoersel.forespurtData.toJson(ForespurtDataDto.serializer().list())
+            Spleis.Key.FORESPURT_DATA to forespoersel.forespurtData.toJson(SpleisForespurtDataDto.serializer().list())
         )
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiverTest.kt
@@ -15,9 +15,9 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.Env.fromEnv
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselMottatt
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Periode
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.PriProducer
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.spleis.Spleis
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockForespoerselDto
@@ -47,7 +47,7 @@ class LagreKomplettForespoerselRiverTest : FunSpec({
             Spleis.Key.SKJÆRINGSTIDSPUNKT to forespoersel.skjaeringstidspunkt?.toJson(),
             Spleis.Key.SYKMELDINGSPERIODER to forespoersel.sykmeldingsperioder.toJson(Periode.serializer().list()),
             Spleis.Key.EGENMELDINGSPERIODER to forespoersel.egenmeldingsperioder.toJson(Periode.serializer().list()),
-            Spleis.Key.FORESPURT_DATA to forespoersel.forespurtData.toJson(ForespurtDataDto.serializer().list())
+            Spleis.Key.FORESPURT_DATA to forespoersel.forespurtData.toJson(SpleisForespurtDataDto.serializer().list())
         )
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvarTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvarTest.kt
@@ -104,12 +104,12 @@ private fun ForespoerselSvar.Suksess.hardcodedJson(): String =
     }
     """.removeJsonWhitespace()
 
-private fun List<ForespurtDataDto>.hardcodedJson(): String =
+private fun List<SpleisForespurtDataDto>.hardcodedJson(): String =
     joinToString(prefix = "[", postfix = "]") {
         when (it) {
-            is ArbeidsgiverPeriode ->
+            is SpleisArbeidsgiverperiode ->
                 """{ "opplysningstype": "Arbeidsgiverperiode" }"""
-            is Inntekt ->
+            is SpleisInntekt ->
                 """
                 {
                     "opplysningstype": "Inntekt",
@@ -118,18 +118,18 @@ private fun List<ForespurtDataDto>.hardcodedJson(): String =
                     }
                 }
                 """
-            is FastsattInntekt ->
+            is SpleisFastsattInntekt ->
                 """
                 {
                     "opplysningstype": "FastsattInntekt",
                     "fastsattInntekt": ${it.fastsattInntekt}
                 }
                 """
-            is Refusjon ->
+            is SpleisRefusjon ->
                 """
                 {
                     "opplysningstype": "Refusjon", 
-                    "forslag": [${it.forslag.joinToString(transform = ForslagRefusjon::hardcodedJson)}]
+                    "forslag": [${it.forslag.joinToString(transform = SpleisForslagRefusjon::hardcodedJson)}]
                 }
                 """
         }
@@ -143,7 +143,7 @@ private fun Periode.hardcodedJson(): String =
     }
     """
 
-private fun ForslagRefusjon.hardcodedJson(): String =
+private fun SpleisForslagRefusjon.hardcodedJson(): String =
     """
     {
         "fom": "$fom",

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespurtDataDtoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespurtDataDtoTest.kt
@@ -24,7 +24,7 @@ class ForespurtDataDtoTest : FunSpec({
             test("Forespurt data serialiseres korrekt") {
                 val forespurtDataListe = mockDataFn()
 
-                val serialisertJson = forespurtDataListe.toJsonStr(ForespurtDataDto.serializer().list())
+                val serialisertJson = forespurtDataListe.toJsonStr(SpleisForespurtDataDto.serializer().list())
 
                 withClue("Validerer mot '$fileName'") {
                     serialisertJson shouldBe expectedJson
@@ -34,7 +34,7 @@ class ForespurtDataDtoTest : FunSpec({
             test("Forespurt data deserialiseres korrekt") {
                 val forespurtDataListe = mockDataFn()
 
-                val deserialisertJson = expectedJson.parseJson().fromJson(ForespurtDataDto.serializer().list())
+                val deserialisertJson = expectedJson.parseJson().fromJson(SpleisForespurtDataDto.serializer().list())
 
                 withClue("Validerer mot '$fileName'") {
                     deserialisertJson shouldContainExactly forespurtDataListe
@@ -43,6 +43,7 @@ class ForespurtDataDtoTest : FunSpec({
         }
 })
 
-private fun String.readResource(): String = ClassLoader.getSystemClassLoader()
-    .getResource(this)
-    ?.readText()!!
+private fun String.readResource(): String =
+    ClassLoader.getSystemClassLoader()
+        .getResource(this)
+        ?.readText()!!

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
@@ -1,19 +1,19 @@
 package no.nav.helsearbeidsgiver.bro.sykepenger.testutils
 
 import kotlinx.serialization.json.JsonElement
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ArbeidsgiverPeriode
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.FastsattInntekt
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselMottatt
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselSvar
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespurtDataDto
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForslagInntekt
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForslagRefusjon
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Inntekt
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.InntektsmeldingHaandtertDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Periode
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Refusjon
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisArbeidsgiverperiode
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisFastsattInntekt
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForslagInntekt
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForslagRefusjon
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisInntekt
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisRefusjon
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
@@ -48,11 +48,11 @@ fun mockForespoerselDto(dokumentId: UUID? = null): ForespoerselDto =
         type = Type.KOMPLETT
     )
 
-fun mockForespurtDataListe(): List<ForespurtDataDto> =
+fun mockForespurtDataListe(): List<SpleisForespurtDataDto> =
     listOf(
-        ArbeidsgiverPeriode,
-        Inntekt(
-            forslag = ForslagInntekt(
+        SpleisArbeidsgiverperiode,
+        SpleisInntekt(
+            forslag = SpleisForslagInntekt(
                 beregningsmåneder = listOf(
                     oktober(2017),
                     november(2017),
@@ -60,29 +60,29 @@ fun mockForespurtDataListe(): List<ForespurtDataDto> =
                 )
             )
         ),
-        Refusjon(
+        SpleisRefusjon(
             forslag = listOf(
-                ForslagRefusjon(17.mai, null, 13.37)
+                SpleisForslagRefusjon(17.mai, null, 13.37)
             )
         )
     )
 
-fun mockBegrensetForespurtDataListe(): List<ForespurtDataDto> =
+fun mockBegrensetForespurtDataListe(): List<SpleisForespurtDataDto> =
     listOf(
-        ArbeidsgiverPeriode,
-        Inntekt(forslag = ForslagInntekt(beregningsmåneder = emptyList())),
-        Refusjon(forslag = emptyList())
+        SpleisArbeidsgiverperiode,
+        SpleisInntekt(forslag = SpleisForslagInntekt(beregningsmåneder = emptyList())),
+        SpleisRefusjon(forslag = emptyList())
     )
 
-fun mockForespurtDataMedFastsattInntektListe(): List<ForespurtDataDto> =
+fun mockForespurtDataMedFastsattInntektListe(): List<SpleisForespurtDataDto> =
     listOf(
-        ArbeidsgiverPeriode,
-        FastsattInntekt(
+        SpleisArbeidsgiverperiode,
+        SpleisFastsattInntekt(
             fastsattInntekt = 31415.92
         ),
-        Refusjon(
+        SpleisRefusjon(
             listOf(
-                ForslagRefusjon(1.januar, null, 31415.92)
+                SpleisForslagRefusjon(1.januar, null, 31415.92)
             )
         )
     )


### PR DESCRIPTION
I seg selv er ikke denne endringen nødvending, men tar den i egen PR for å gjøre diffen i https://github.com/navikt/helsearbeidsgiver-bro-sykepenger/pull/8 lettere å komme seg gjennom.