### PR TITLE
Fjern default null for forrige inntekt

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
@@ -96,7 +96,7 @@ class TilgjengeliggjoerForespoerselRiver(
         )
 
         loggernaut.aapen.info("Behov besvart på pri-topic med forespørsel.")
-        loggernaut.sikker.info("Behov besvart på pri-topic med forespørsel: $forespoerselSvarJson")
+        loggernaut.sikker.info("Behov besvart på pri-topic med forespørsel: ${forespoerselSvarJson.toPretty()}")
     }
 
     override fun onError(problems: MessageProblems, context: MessageContext) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
@@ -73,7 +73,7 @@ class TilgjengeliggjoerForespoerselRiver(
         loggernaut.aapen.info("Mottok melding på pri-topic av type '${Pri.Key.BEHOV.les(String.serializer(), melding)}'.")
         loggernaut.sikker.info("Mottok melding på pri-topic med innhold:\n${toPretty()}")
 
-        val forespoerselSvar = ForespoerselSvar(
+        val forespoerselSvarJson = ForespoerselSvar(
             forespoerselId = forespoerselId,
             boomerang = Pri.Key.BOOMERANG.les(JsonElement.serializer(), melding)
         )
@@ -88,14 +88,15 @@ class TilgjengeliggjoerForespoerselRiver(
                     it.copy(feil = ForespoerselSvar.Feil.FORESPOERSEL_IKKE_FUNNET)
                 }
             }
+            .toJson(ForespoerselSvar.serializer())
 
         priProducer.send(
             Pri.Key.BEHOV to ForespoerselSvar.behovType.toJson(Pri.BehovType.serializer()),
-            Pri.Key.LØSNING to forespoerselSvar.toJson(ForespoerselSvar.serializer())
+            Pri.Key.LØSNING to forespoerselSvarJson
         )
 
         loggernaut.aapen.info("Behov besvart på pri-topic med forespørsel.")
-        loggernaut.sikker.info("Behov besvart på pri-topic med forespørsel: $forespoerselSvar")
+        loggernaut.sikker.info("Behov besvart på pri-topic med forespørsel: $forespoerselSvarJson")
     }
 
     override fun onError(problems: MessageProblems, context: MessageContext) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespurtData.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespurtData.kt
@@ -53,7 +53,7 @@ sealed class ForslagInntekt {
     // TODO erstatt med skjæringstidspunkt?
     data class Grunnlag(
         val beregningsmaaneder: List<YearMonth>,
-        val forrigeInntekt: ForrigeInntekt? = null
+        val forrigeInntekt: ForrigeInntekt?
     ) : ForslagInntekt()
 
     @Serializable

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MapForespurtDataKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MapForespurtDataKtTest.kt
@@ -87,7 +87,8 @@ class MapForespurtDataKtTest : FunSpec({
                             juni(2010),
                             juli(2010),
                             august(2010)
-                        )
+                        ),
+                        forrigeInntekt = null
                     )
                 ),
                 refusjon = Refusjon.ikkePaakrevd()

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvarTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvarTest.kt
@@ -130,7 +130,8 @@ private fun ForslagInntekt.hardcodedJson(): String =
             """
             {
                 "type": "ForslagInntektGrunnlag",
-                "beregningsmaaneder": [${beregningsmaaneder.joinToString { yearMonth -> "\"$yearMonth\"" }}]
+                "beregningsmaaneder": [${beregningsmaaneder.joinToString { yearMonth -> "\"$yearMonth\"" }}],
+                "forrigeInntekt": null
             }
             """
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
@@ -188,7 +188,8 @@ fun mockInntektMedForslagGrunnlag(): Inntekt =
                 august(1999),
                 september(1999),
                 oktober(1999)
-            )
+            ),
+            forrigeInntekt = null
         )
     )
 


### PR DESCRIPTION
Fjerner defaulten slik at feltet alltid blir serialisert, selv ved null-verdier.