### PR TITLE
Ikke lagre duplikater av forespørsler

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreForespoerselRiver.kt
@@ -13,6 +13,7 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.PriProducer
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.spleis.Spleis
+import no.nav.helsearbeidsgiver.bro.sykepenger.utils.Log
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.Loggernaut
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.les
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.randomUuid
@@ -37,7 +38,8 @@ sealed class LagreForespoerselRiver(
         val forespoerselId = randomUuid()
 
         MdcUtils.withLogFields(
-            "forespoerselId" to forespoerselId.toString()
+            Log.klasse(this),
+            Log.forespoerselId(forespoerselId)
         ) {
             runCatching {
                 packet.toJson()
@@ -58,25 +60,43 @@ sealed class LagreForespoerselRiver(
         loggernaut.aapen.info("Mottok melding av type '${Spleis.Key.TYPE.les(String.serializer(), melding)}'")
         loggernaut.sikker.info("Mottok melding med innhold:\n${toPretty()}")
 
-        val forespoersel = lesForespoersel(forespoerselId, melding)
-        loggernaut.sikker.info("Forespoersel lest: $forespoersel")
+        val nyForespoersel = lesForespoersel(forespoerselId, melding)
+        loggernaut.sikker.info("Forespoersel lest: $nyForespoersel")
 
-        val erNyForespoerselForVedtaksperiode = forespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId) == null
-        forespoerselDao.lagre(forespoersel)
-            .let { id ->
-                if (id != null) {
-                    loggernaut.aapen.info("Forespørsel lagret med id=$id.")
-                } else {
-                    loggernaut.aapen.error("Forespørsel ble ikke lagret.")
+        MdcUtils.withLogFields(
+            Log.type(nyForespoersel.type),
+            Log.vedtaksperiodeId(nyForespoersel.vedtaksperiodeId)
+        ) {
+            lagreForespoersel(nyForespoersel)
+        }
+    }
+
+    private fun lagreForespoersel(nyForespoersel: ForespoerselDto) {
+        val aktivForespoersel = forespoerselDao.hentAktivForespoerselForVedtaksperiodeId(nyForespoersel.vedtaksperiodeId)
+
+        if (aktivForespoersel == null || !nyForespoersel.erDuplikatAv(aktivForespoersel)) {
+            forespoerselDao.lagre(nyForespoersel)
+                .let { id ->
+                    if (id != null) {
+                        loggernaut.aapen.info("Forespørsel lagret med id=$id.")
+                    } else {
+                        loggernaut.aapen.error("Forespørsel ble ikke lagret.")
+                    }
                 }
+        } else {
+            "Lagret ikke duplikatforespørsel.".also {
+                loggernaut.aapen.info(it)
+                loggernaut.sikker.info(it)
             }
+        }
 
-        if (erNyForespoerselForVedtaksperiode) {
+        // Ikke send notis ved oppdatering av forespørsel som er ubesvart
+        if (aktivForespoersel == null) {
             priProducer.send(
                 Pri.Key.NOTIS to ForespoerselMottatt.notisType.toJson(Pri.NotisType.serializer()),
-                Pri.Key.FORESPOERSEL_ID to forespoersel.forespoerselId.toJson(),
-                Pri.Key.ORGNR to forespoersel.orgnr.toJson(Orgnr.serializer()),
-                Pri.Key.FNR to forespoersel.fnr.toJson()
+                Pri.Key.FORESPOERSEL_ID to nyForespoersel.forespoerselId.toJson(),
+                Pri.Key.ORGNR to nyForespoersel.orgnr.toJson(Orgnr.serializer()),
+                Pri.Key.FNR to nyForespoersel.fnr.toJson()
             )
                 .ifTrue { loggernaut.aapen.info("Sa ifra om mottatt forespørsel til Simba.") }
                 .ifFalse { loggernaut.aapen.error("Klarte ikke si ifra om mottatt forespørsel til Simba.") }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreForespoerselRiver.kt
@@ -78,9 +78,15 @@ sealed class LagreForespoerselRiver(
             forespoerselDao.lagre(nyForespoersel)
                 .let { id ->
                     if (id != null) {
-                        loggernaut.aapen.info("Forespørsel lagret med id=$id.")
+                        "Forespørsel lagret med id=$id.".also {
+                            loggernaut.aapen.info(it)
+                            loggernaut.sikker.info(it)
+                        }
                     } else {
-                        loggernaut.aapen.error("Forespørsel ble ikke lagret.")
+                        "Forespørsel ble ikke lagret.".also {
+                            loggernaut.aapen.error(it)
+                            loggernaut.sikker.error(it)
+                        }
                     }
                 }
         } else {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
@@ -24,7 +24,15 @@ data class ForespoerselDto(
     val besvarelse: BesvarelseMetadataDto?,
     val opprettet: LocalDateTime = LocalDateTime.now().truncMillis(),
     val oppdatert: LocalDateTime = LocalDateTime.now().truncMillis()
-)
+) {
+    fun erDuplikatAv(other: ForespoerselDto): Boolean =
+        this == other.copy(
+            forespoerselId = forespoerselId,
+            besvarelse = besvarelse,
+            opprettet = opprettet,
+            oppdatert = oppdatert
+        )
+}
 
 data class BesvarelseMetadataDto(
     val forespoerselBesvart: LocalDateTime,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/utils/Log.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/utils/Log.kt
@@ -1,0 +1,21 @@
+package no.nav.helsearbeidsgiver.bro.sykepenger.utils
+
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
+import java.util.UUID
+
+object Log {
+    fun <T : Any> klasse(value: T): Pair<String, String> =
+        "class" to value.simpleName()
+
+    fun forespoerselId(value: UUID): Pair<String, String> =
+        "forespoersel_id" to value.toString()
+
+    fun type(value: Type): Pair<String, String> =
+        "forespoersel_type" to value.name
+
+    fun vedtaksperiodeId(value: UUID): Pair<String, String> =
+        "vedtaksperiode_id" to value.toString()
+}
+
+private fun <T : Any> T.simpleName(): String =
+    this::class.simpleName.orEmpty()

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiverTest.kt
@@ -5,8 +5,8 @@ import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.verify
 import io.mockk.verifySequence
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
@@ -23,6 +23,7 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.toKeyMap
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.test.date.mars
 
 class LagreKomplettForespoerselRiverTest : FunSpec({
     val testRapid = TestRapid()
@@ -52,17 +53,15 @@ class LagreKomplettForespoerselRiverTest : FunSpec({
         clearAllMocks()
     }
 
-    test("Innkommende forespørsel blir lagret og sender notifikasjon videre") {
+    test("Forespørsel blir lagret og sender notifikasjon") {
         val forespoersel = mockForespoerselDto()
 
-        mockkObject(Env) {
-            every { mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId) } returns null
+        every { mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId) } returns null
 
-            mockkStatic(::randomUuid) {
-                every { randomUuid() } returns forespoersel.forespoerselId
+        mockkStatic(::randomUuid) {
+            every { randomUuid() } returns forespoersel.forespoerselId
 
-                mockInnkommendeMelding(forespoersel)
-            }
+            mockInnkommendeMelding(forespoersel)
         }
 
         val expectedPublished = ForespoerselMottatt(
@@ -85,45 +84,59 @@ class LagreKomplettForespoerselRiverTest : FunSpec({
         }
     }
 
-    test("Sender ikke notifikasjon til simba når en forespørsel oppdateres") {
+    test("Oppdatert forespørsel (ubesvart) blir lagret uten notifikasjon") {
         val forespoersel = mockForespoerselDto()
 
-        mockkObject(Env) {
-            every { mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId) } returns null andThen forespoersel
-
-            mockkStatic(::randomUuid) {
-                every { randomUuid() } returns forespoersel.forespoerselId
-
-                mockInnkommendeMelding(forespoersel)
-                mockInnkommendeMelding(forespoersel)
-            }
-        }
-
-        val expectedPublished = ForespoerselMottatt(
-            forespoerselId = forespoersel.forespoerselId,
-            orgnr = forespoersel.orgnr,
-            fnr = forespoersel.fnr
+        every {
+            mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId)
+        } returns forespoersel.copy(
+            egenmeldingsperioder = listOf(
+                Periode(13.mars(1812), 14.mars(1812))
+            )
         )
 
-        // Forventer at priProducer.send _ikke_ skal bli kalt ved andre forespørsel
+        mockkStatic(::randomUuid) {
+            every { randomUuid() } returns forespoersel.forespoerselId
+
+            mockInnkommendeMelding(forespoersel)
+        }
+
         verifySequence {
             mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId)
+
             mockForespoerselDao.lagre(
                 withArg {
                     it.shouldBeEqualToIgnoringFields(forespoersel, forespoersel::oppdatert, forespoersel::opprettet)
                 }
             )
+        }
 
-            mockPriProducer.send(
-                *expectedPublished.toKeyMap().toList().toTypedArray()
-            )
+        verify(exactly = 0) {
+            mockPriProducer.send(any())
+        }
+    }
 
+    test("Duplisert forespørsel blir hverken lagret eller sender notifikasjon") {
+        val forespoersel = mockForespoerselDto()
+
+        every {
             mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId)
-            mockForespoerselDao.lagre(
-                withArg {
-                    it.shouldBeEqualToIgnoringFields(forespoersel, forespoersel::oppdatert, forespoersel::opprettet)
-                }
-            )
+        } returns forespoersel
+
+        mockkStatic(::randomUuid) {
+            every { randomUuid() } returns forespoersel.forespoerselId
+
+            mockInnkommendeMelding(forespoersel)
+        }
+
+        verifySequence {
+            mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId)
+        }
+
+        verify(exactly = 0) {
+            mockForespoerselDao.lagre(any())
+
+            mockPriProducer.send(any())
         }
     }
 })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDaoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDaoTest.kt
@@ -387,7 +387,7 @@ class ForespoerselDaoTest : AbstractDatabaseFunSpec({ dataSource ->
     }
 
     test("Oppdaterer ikke besvart forespørsel til forkastet") {
-        val forespoerselId = mockForespoerselDto(status = Status.BESVART).lagreNotNull()
+        val forespoerselId = mockForespoerselDto().copy(status = Status.BESVART).lagreNotNull()
         forespoerselDao.oppdaterForespoerselSomForkastet(MockUuid.vedtaksperiodeId)
 
         val forespoersel = dataSource.hentForespoersel(forespoerselId)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDtoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDtoTest.kt
@@ -1,0 +1,71 @@
+package no.nav.helsearbeidsgiver.bro.sykepenger.domene
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockForespoerselDto
+import no.nav.helsearbeidsgiver.utils.test.date.september
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ForespoerselDtoTest : FunSpec({
+    context("erDuplikat") {
+        withData(
+            mapOf<String, (ForespoerselDto) -> ForespoerselDto>(
+                "Aksepterer helt like" to { it },
+                "Ignorerer 'forespoerselId'" to { it.copy(forespoerselId = UUID.randomUUID()) },
+                "Ignorerer 'besvarelse'" to {
+                    it.copy(besvarelse = BesvarelseMetadataDto(LocalDateTime.now(), UUID.randomUUID()))
+                },
+                "Ignorerer 'opprettet'" to { it.copy(opprettet = LocalDateTime.now().minusDays(5)) },
+                "Ignorerer 'oppdatert'" to { it.copy(oppdatert = LocalDateTime.now().plusDays(10)) }
+            )
+        ) { endreFn ->
+            val original = mockForespoerselDto()
+
+            val endret = endreFn(original)
+
+            original.erDuplikatAv(endret).shouldBeTrue()
+        }
+
+        withData(
+            mapOf<String, (ForespoerselDto) -> ForespoerselDto>(
+                "Oppdager ulik 'type'" to { it.copy(type = Type.BEGRENSET) },
+                "Oppdager ulik 'status'" to { it.copy(status = Status.FORKASTET) },
+                "Oppdager ulik 'orgnr'" to { it.copy(orgnr = "999777555".let(::Orgnr)) },
+                "Oppdager ulik 'fnr'" to { it.copy(fnr = "22244466688") },
+                "Oppdager ulik 'vedtaksperiodeId'" to { it.copy(vedtaksperiodeId = UUID.randomUUID()) },
+                "Oppdager ulik 'skjaeringstidspunkt'" to { it.copy(skjaeringstidspunkt = LocalDate.now().plusDays(17)) },
+                "Oppdager ulik 'sykmeldingsperioder'" to {
+                    it.copy(sykmeldingsperioder = listOf(Periode(22.september(1774), 24.september(1774))))
+                },
+                "Oppdager ulik 'egenmeldingsperioder'" to {
+                    it.copy(egenmeldingsperioder = listOf(Periode(2.september(1774), 4.september(1774))))
+                },
+                "Oppdager ulik 'forespurtData'" to {
+                    it.copy(
+                        forespurtData = listOf(
+                            SpleisInntekt(
+                                forslag = SpleisForslagInntekt(
+                                    forrigeInntekt = SpleisForrigeInntekt(
+                                        skjæringstidspunkt = LocalDate.now().minusDays(62),
+                                        kilde = "Farris",
+                                        beløp = 12.1
+                                    )
+                                )
+                            )
+                        )
+                    )
+                }
+            )
+        ) { endreFn ->
+            val original = mockForespoerselDto()
+
+            val endret = endreFn(original)
+
+            original.erDuplikatAv(endret).shouldBeFalse()
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/SpleisForespurtDataDtoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/SpleisForespurtDataDtoTest.kt
@@ -14,7 +14,7 @@ import no.nav.helsearbeidsgiver.utils.json.removeJsonWhitespace
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 
-class ForespurtDataDtoTest : FunSpec({
+class SpleisForespurtDataDtoTest : FunSpec({
     listOf(
         row("forespurtDataListe", ::mockSpleisForespurtDataListe),
         row("forespurtDataMedFastsattInntektListe", ::mockForespurtDataMedFastsattInntektListe),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
@@ -2,7 +2,6 @@ package no.nav.helsearbeidsgiver.bro.sykepenger.testutils
 
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Arbeidsgiverperiode
-import no.nav.helsearbeidsgiver.bro.sykepenger.domene.BesvarelseMetadataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselMottatt
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselSvar
@@ -41,13 +40,13 @@ object MockUuid {
     val inntektsmeldingId: UUID = "22efb342-3e72-4880-a449-eb1efcf0f18b".let(UUID::fromString)
 }
 
-fun mockForespoerselDto(besvarelseMetaData: BesvarelseMetadataDto? = null, status: Status = Status.AKTIV): ForespoerselDto =
+fun mockForespoerselDto(): ForespoerselDto =
     ForespoerselDto(
         forespoerselId = randomUuid(),
         type = Type.KOMPLETT,
-        status = status,
+        status = Status.AKTIV,
         orgnr = "123456789".let(::Orgnr),
-        fnr = "123456789",
+        fnr = "11223344556",
         vedtaksperiodeId = MockUuid.vedtaksperiodeId,
         skjaeringstidspunkt = 15.januar,
         sykmeldingsperioder = listOf(
@@ -56,7 +55,7 @@ fun mockForespoerselDto(besvarelseMetaData: BesvarelseMetadataDto? = null, statu
         ),
         egenmeldingsperioder = listOf(Periode(1.januar, 1.januar)),
         forespurtData = mockSpleisForespurtDataListe(),
-        besvarelse = besvarelseMetaData
+        besvarelse = null
     )
 
 fun mockSpleisForespurtDataListe(): List<SpleisForespurtDataDto> =


### PR DESCRIPTION
Ifølge spleis så er duplikatsjekken aktuell for aktive forespørsler, men ikke besvarte.