### PR TITLE
Marker forespørsel som besvart fra Simba

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/App.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/App.kt
@@ -21,6 +21,7 @@ fun main() {
 
     LagreKomplettForespoerselRiver(rapid = rapid, forespoerselDao = forespoerselDao, priProducer = priProducer)
     TilgjengeliggjoerForespoerselRiver(rapid = rapid, forespoerselDao = forespoerselDao, priProducer = priProducer)
+    MarkerBesvartFraSimbaRiver(rapid = rapid, forespoerselDao = forespoerselDao)
     MarkerBesvartFraSpleisRiver(rapid = rapid, forespoerselDao = forespoerselDao, priProducer = priProducer)
     ForkastForespoerselRiver(rapid = rapid, forespoerselDao = forespoerselDao, priProducer = priProducer)
     // NB! Denne skal ikke registreres før portalen er klar for å vise begrensede forespørsler

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/ForkastForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/ForkastForespoerselRiver.kt
@@ -69,7 +69,7 @@ internal class ForkastForespoerselRiver(
         val forespoersel = forespoerselDao.hentAktivForespoerselForVedtaksperiodeId(vedtaksperiodeId)
 
         if (forespoersel != null) {
-            forespoerselDao.oppdaterForespoerselSomForkastet(vedtaksperiodeId)
+            forespoerselDao.oppdaterForespoerslerSomForkastet(vedtaksperiodeId)
             "Oppdaterte status til forkastet for forespørsel ${forespoersel.forespoerselId}.".also {
                 loggernaut.aapen.info(it)
                 loggernaut.sikker.info(it)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiver.kt
@@ -1,0 +1,83 @@
+package no.nav.helsearbeidsgiver.bro.sykepenger
+
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
+import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
+import no.nav.helsearbeidsgiver.bro.sykepenger.utils.Loggernaut
+import no.nav.helsearbeidsgiver.bro.sykepenger.utils.demandValues
+import no.nav.helsearbeidsgiver.bro.sykepenger.utils.les
+import no.nav.helsearbeidsgiver.bro.sykepenger.utils.requireKeys
+import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
+import no.nav.helsearbeidsgiver.utils.json.parseJson
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
+import no.nav.helsearbeidsgiver.utils.json.toPretty
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
+import java.time.LocalDateTime
+import java.util.UUID
+
+class MarkerBesvartFraSimbaRiver(
+    rapid: RapidsConnection,
+    private val forespoerselDao: ForespoerselDao,
+) : River.PacketListener {
+    private val loggernaut = Loggernaut(this)
+
+    init {
+        River(rapid).apply {
+            validate { msg ->
+                msg.demandValues(Pri.Key.NOTIS to Pri.NotisType.FORESPOERSEL_BESVART_SIMBA.name)
+                msg.requireKeys(Pri.Key.FORESPOERSEL_ID)
+            }
+        }.register(this)
+    }
+
+    override fun onPacket(
+        packet: JsonMessage,
+        context: MessageContext,
+    ) {
+        val json = packet.toJson().parseJson()
+
+        loggernaut.aapen.info("Mottok melding på pri-topic av type '${Pri.NotisType.FORESPOERSEL_BESVART_SIMBA}'.")
+        loggernaut.sikker.info("Mottok melding på pri-topic med innhold:\n${json.toPretty()}")
+
+        val forespoerselId =
+            Pri.Key.FORESPOERSEL_ID.les(
+                UuidSerializer,
+                json.fromJsonMapFiltered(Pri.Key.serializer()),
+            )
+
+        MdcUtils.withLogFields(
+            "forespoerselId" to forespoerselId.toString(),
+        ) {
+            runCatching {
+                markerBesvart(forespoerselId)
+            }
+                .onFailure(loggernaut::ukjentFeil)
+        }
+    }
+
+    private fun markerBesvart(forespoerselId: UUID) {
+        val forespoersel = forespoerselDao.hentForespoerselForForespoerselId(forespoerselId)
+
+        if (forespoersel != null) {
+            val antallOppdaterte =
+                forespoerselDao.oppdaterForespoerslerSomBesvartFraSimba(
+                    vedtaksperiodeId = forespoersel.vedtaksperiodeId,
+                    besvart = LocalDateTime.now(),
+                )
+
+            if (antallOppdaterte > 0) {
+                if (forespoersel.status == Status.AKTIV) {
+                    loggernaut.info("Oppdaterte status til besvart fra Simba for forespørsel ${forespoersel.forespoerselId}.")
+                }
+            } else {
+                loggernaut.error("Ingen forespørsler ble markert som besvart fra Simba.")
+            }
+        } else {
+            loggernaut.error("Fant ingen forespørsel å markere som besvart fra Simba.")
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
@@ -85,9 +85,9 @@ class TilgjengeliggjoerForespoerselRiver(
             )
                 .let {
                     val forespoersel =
-                        forespoerselDao.hentForespoerselForForespoerselId(
+                        forespoerselDao.hentNyesteForespoerselForForespoerselId(
                             forespoerselId = it.forespoerselId,
-                            statuser = setOf(Status.AKTIV, Status.BESVART_SPLEIS),
+                            statuser = setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
                         )
 
                     if (forespoersel != null) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
@@ -246,6 +246,11 @@ class ForespoerselDao(private val dataSource: DataSource) {
                 session = session,
                 transform = Row::toId,
             )
+            .also {
+                val msg = "Oppdaterte ${it.size} rader med ny status '$nyStatus'. ids=$it"
+                logger.info(msg)
+                sikkerLogger.info(msg)
+            }
 
     private fun insertOrUpdateBesvarelse(
         session: TransactionalSession,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
@@ -16,6 +16,7 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.utils.listResult
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.nullableResult
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.splitOnIndex
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.updateAndReturnGeneratedKey
+import no.nav.helsearbeidsgiver.bro.sykepenger.utils.updateResult
 import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
@@ -61,41 +62,36 @@ class ForespoerselDao(private val dataSource: DataSource) {
         return sessionOf(
             dataSource = dataSource,
             returnGeneratedKey = true,
-        ).use { session ->
-            session.transaction {
-                forkastAlleAktiveForespoerslerFor(forespoersel.vedtaksperiodeId, it)
+        ).useTransaction {
+            oppdaterStatuser(
+                session = it,
+                vedtaksperiodeId = forespoersel.vedtaksperiodeId,
+                erstattStatuser = setOf(Status.AKTIV),
+                nyStatus = Status.FORKASTET,
+            )
 
-                "INSERT INTO forespoersel($kolonnenavn) VALUES ($noekler)"
-                    .updateAndReturnGeneratedKey(
-                        params = felter + jsonFelter,
-                        session = it,
-                    )
-            }
+            "INSERT INTO forespoersel($kolonnenavn) VALUES ($noekler)"
+                .updateAndReturnGeneratedKey(
+                    params = felter + jsonFelter,
+                    session = it,
+                )
         }
     }
 
-    private fun forkastAlleAktiveForespoerslerFor(
-        vedtaksperiodeId: UUID,
-        session: TransactionalSession,
-    ): Boolean =
-        "UPDATE forespoersel SET ${Db.STATUS}=:nyStatus WHERE ${Db.VEDTAKSPERIODE_ID}=:vedtaksperiodeId AND ${Db.STATUS}=:gammelStatus"
-            .execute(
-                params =
-                    mapOf(
-                        "vedtaksperiodeId" to vedtaksperiodeId,
-                        "nyStatus" to Status.FORKASTET.name,
-                        "gammelStatus" to Status.AKTIV.name,
-                    ),
-                session = session,
-            )
-
-    fun oppdaterForespoerslerSomBesvart(
+    fun oppdaterForespoerslerSomBesvartFraSpleis(
         vedtaksperiodeId: UUID,
         besvart: LocalDateTime,
         inntektsmeldingId: UUID?,
-    ) = sessionOf(dataSource = dataSource).use { session ->
-        session.transaction { transaction ->
-            val oppdaterteForespoersler = oppdaterAktiveOgBesvarteStatuser(transaction, vedtaksperiodeId, Status.BESVART_SPLEIS)
+    ): Int =
+        sessionOf(dataSource = dataSource).useTransaction { transaction ->
+            val oppdaterteForespoersler =
+                oppdaterStatuser(
+                    session = transaction,
+                    vedtaksperiodeId = vedtaksperiodeId,
+                    erstattStatuser = setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
+                    nyStatus = Status.BESVART_SPLEIS,
+                )
+
             if (oppdaterteForespoersler.isEmpty()) {
                 val msg =
                     "Fant ingen aktive eller besvarte forespørsler for vedtaksperioden $vedtaksperiodeId. " +
@@ -103,52 +99,153 @@ class ForespoerselDao(private val dataSource: DataSource) {
                 logger.warn(msg)
                 sikkerLogger.warn(msg)
             }
+
             oppdaterteForespoersler.forEach { id ->
                 insertOrUpdateBesvarelse(transaction, id, besvart, inntektsmeldingId)
             }
+
+            oppdaterteForespoersler.size
+        }
+
+    fun oppdaterForespoerslerSomBesvartFraSimba(
+        vedtaksperiodeId: UUID,
+        besvart: LocalDateTime,
+    ): Int =
+        sessionOf(dataSource = dataSource).useTransaction { transaction ->
+            val oppdaterteForespoersler =
+                oppdaterStatuser(
+                    session = transaction,
+                    vedtaksperiodeId = vedtaksperiodeId,
+                    erstattStatuser = setOf(Status.AKTIV, Status.BESVART_SIMBA),
+                    nyStatus = Status.BESVART_SIMBA,
+                )
+
+            oppdaterteForespoersler.forEach { id ->
+                insertOrUpdateBesvarelse(transaction, id, besvart, null)
+            }
+
+            oppdaterteForespoersler.size
+        }
+
+    fun oppdaterForespoerslerSomForkastet(vedtaksperiodeId: UUID) {
+        sessionOf(dataSource = dataSource).use {
+            oppdaterStatuser(
+                session = it,
+                vedtaksperiodeId = vedtaksperiodeId,
+                erstattStatuser = setOf(Status.AKTIV),
+                nyStatus = Status.FORKASTET,
+            )
         }
     }
 
-    fun oppdaterForespoerselSomForkastet(vedtaksperiodeId: UUID) =
-        sessionOf(dataSource = dataSource).use { oppdaterAktivStatus(it, vedtaksperiodeId, Status.FORKASTET) }
-
-    private fun oppdaterAktiveOgBesvarteStatuser(
-        session: TransactionalSession,
-        vedtaksperiodeId: UUID,
-        status: Status,
-    ) = query(
-        "UPDATE forespoersel",
-        "SET ${Db.STATUS}=:nyStatus",
-        "WHERE ${Db.VEDTAKSPERIODE_ID}=:vedtaksperiodeId AND ${Db.STATUS} in",
-        "('${Status.AKTIV.name}', '${Status.BESVART_SPLEIS.name}')",
-        "RETURNING id",
-    )
-        .listResult(
-            params =
-                mutableMapOf(
-                    "vedtaksperiodeId" to vedtaksperiodeId,
-                    "nyStatus" to status.name,
-                ),
-            session = session,
-            transform = Row::toId,
+    fun hentForespoerselForForespoerselId(forespoerselId: UUID): ForespoerselDto? =
+        query(
+            "SELECT *",
+            "FROM forespoersel f",
+            "LEFT JOIN besvarelse_metadata b ON f.id=b.${Db.FK_FORESPOERSEL_ID}",
+            "WHERE ${Db.FORESPOERSEL_ID}=:forespoerselId",
         )
+            .nullableResult(
+                params = mapOf("forespoerselId" to forespoerselId),
+                dataSource = dataSource,
+                transform = Row::toForespoerselDto,
+            )
 
-    private fun oppdaterAktivStatus(
+    fun hentNyesteForespoerselForForespoerselId(
+        forespoerselId: UUID,
+        statuser: Set<Status>,
+    ): ForespoerselDto? =
+        hentVedtaksperiodeId(forespoerselId)?.let { vedtaksperiodeId ->
+            hentForespoerslerForVedtaksperiodeId(
+                vedtaksperiodeId = vedtaksperiodeId,
+                statuser = statuser,
+            )
+                .maxByOrNull { it.opprettet }
+        }
+
+    fun hentAktivForespoerselForVedtaksperiodeId(vedtaksperiodeId: UUID): ForespoerselDto? =
+        hentForespoerslerForVedtaksperiodeId(vedtaksperiodeId, setOf(Status.AKTIV))
+            .also { forespoersler ->
+                if (forespoersler.size > 1) {
+                    "Fant flere aktive forespørsler for vedtaksperiode: $vedtaksperiodeId".also {
+                        logger.error(it)
+                        sikkerLogger.error(it)
+                    }
+                }
+            }
+            .maxByOrNull { it.opprettet }
+
+    fun forespoerselIdEksponertTilSimba(vedtaksperiodeId: UUID): UUID? {
+        val forespoersler =
+            hentForespoerslerForVedtaksperiodeId(vedtaksperiodeId, Status.entries.toSet())
+                .sortedBy { it.opprettet }
+
+        val besvarteIndekser =
+            forespoersler.mapIndexedNotNull { index, forespoersel ->
+                if (forespoersel.status in listOf(Status.BESVART_SIMBA, Status.BESVART_SPLEIS)) {
+                    index
+                } else {
+                    null
+                }
+            }
+
+        return besvarteIndekser
+            .fold(listOf(forespoersler)) { acc, besvartIndex ->
+                acc.last().splitOnIndex(besvartIndex + 1).toList()
+            }
+            .lastOrNull { it.isNotEmpty() }
+            ?.firstOrNull()
+            ?.forespoerselId
+    }
+
+    private fun hentVedtaksperiodeId(forespoerselId: UUID): UUID? =
+        query(
+            "SELECT ${Db.VEDTAKSPERIODE_ID}",
+            "FROM forespoersel",
+            "WHERE ${Db.FORESPOERSEL_ID}=:forespoerselId",
+        )
+            .nullableResult(
+                params = mapOf("forespoerselId" to forespoerselId),
+                dataSource = dataSource,
+                transform = { Db.VEDTAKSPERIODE_ID.let(::uuid) },
+            )
+
+    private fun hentForespoerslerForVedtaksperiodeId(
+        vedtaksperiodeId: UUID,
+        statuser: Set<Status>,
+    ): List<ForespoerselDto> =
+        query(
+            "SELECT * FROM forespoersel f",
+            "LEFT JOIN besvarelse_metadata b ON f.id=b.${Db.FK_FORESPOERSEL_ID}",
+            "WHERE ${Db.VEDTAKSPERIODE_ID}=:vedtaksperiodeId AND ${Db.STATUS} in (${statuser.joinToString { "'$it'" }})",
+        )
+            .listResult(
+                params = mapOf("vedtaksperiodeId" to vedtaksperiodeId),
+                dataSource = dataSource,
+                transform = Row::toForespoerselDto,
+            )
+
+    private fun oppdaterStatuser(
         session: Session,
         vedtaksperiodeId: UUID,
-        status: Status,
-    ) = query(
-        "UPDATE forespoersel",
-        "SET ${Db.STATUS}=:nyStatus",
-        "WHERE ${Db.VEDTAKSPERIODE_ID}=:vedtaksperiodeId AND ${Db.STATUS}='${Status.AKTIV}'",
-    ).execute(
-        params =
-            mutableMapOf(
-                "vedtaksperiodeId" to vedtaksperiodeId,
-                "nyStatus" to status.name,
-            ),
-        session = session,
-    )
+        erstattStatuser: Set<Status>,
+        nyStatus: Status,
+    ): List<Long> =
+        query(
+            "UPDATE forespoersel",
+            "SET ${Db.STATUS}=:nyStatus",
+            "WHERE ${Db.VEDTAKSPERIODE_ID}=:vedtaksperiodeId AND ${Db.STATUS} in (${erstattStatuser.joinToString { "'$it'" }})",
+            "RETURNING id",
+        )
+            .updateResult(
+                params =
+                    mapOf(
+                        "vedtaksperiodeId" to vedtaksperiodeId,
+                        "nyStatus" to nyStatus.name,
+                    ),
+                session = session,
+                transform = Row::toId,
+            )
 
     private fun insertOrUpdateBesvarelse(
         session: TransactionalSession,
@@ -172,84 +269,6 @@ class ForespoerselDao(private val dataSource: DataSource) {
                         .mapValuesNotNull { it },
                 session = session,
             )
-
-    fun hentForespoerselForForespoerselId(
-        forespoerselId: UUID,
-        statuser: Set<Status>,
-    ): ForespoerselDto? =
-        hentVedtaksperiodeId(forespoerselId)?.let { vedtaksperiodeId ->
-            hentForespoerselForVedtaksperiodeId(
-                vedtaksperiodeId = vedtaksperiodeId,
-                statuser = statuser,
-            )
-                .maxByOrNull { it.opprettet }
-        }
-
-    fun hentAktivForespoerselForVedtaksperiodeId(vedtaksperiodeId: UUID): ForespoerselDto? =
-        hentForespoerselForVedtaksperiodeId(vedtaksperiodeId, setOf(Status.AKTIV))
-            .also { forespoersler ->
-                if (forespoersler.size > 1) {
-                    "Fant flere aktive forespørsler for vedtaksperiode: $vedtaksperiodeId".also {
-                        logger.error(it)
-                        sikkerLogger.error(it)
-                    }
-                }
-            }
-            .maxByOrNull { it.opprettet }
-
-    private fun hentForespoerselForVedtaksperiodeId(
-        vedtaksperiodeId: UUID,
-        statuser: Set<Status>,
-    ): List<ForespoerselDto> =
-        query(
-            "SELECT * FROM forespoersel f",
-            "LEFT JOIN besvarelse_metadata b ON f.id=b.${Db.FK_FORESPOERSEL_ID}",
-            "WHERE ${Db.VEDTAKSPERIODE_ID}=:vedtaksperiodeId AND ${Db.STATUS} in (${statuser.joinToString { "'$it'" }})",
-        )
-            .listResult(
-                params = mapOf("vedtaksperiodeId" to vedtaksperiodeId),
-                dataSource = dataSource,
-                transform = Row::toForespoerselDto,
-            )
-
-    fun forespoerselIdKnyttetTilOppgaveIPortalen(vedtaksperiodeId: UUID): UUID? {
-        val forespoersler = hentAlleForespoerslerKnyttetTil(vedtaksperiodeId).sortedBy { it.opprettet }
-        val besvarteIndekser =
-            forespoersler.mapIndexedNotNull { index, forespoersel ->
-                if (forespoersel.status in listOf(Status.BESVART_SPLEIS)) {
-                    index
-                } else {
-                    null
-                }
-            }
-        return besvarteIndekser
-            .fold(listOf(forespoersler)) { acc, cur ->
-                acc.last().splitOnIndex(cur + 1).toList()
-            }
-            .lastOrNull { it.isNotEmpty() }
-            ?.firstOrNull()
-            ?.forespoerselId
-    }
-
-    fun hentAlleForespoerslerKnyttetTil(vedtaksperiodeId: UUID): List<ForespoerselDto> =
-        query(
-            "SELECT * FROM forespoersel f",
-            "LEFT JOIN besvarelse_metadata b ON f.id=b.${Db.FK_FORESPOERSEL_ID}",
-            "WHERE ${Db.VEDTAKSPERIODE_ID}=:vedtaksperiodeId",
-        )
-            .listResult(
-                params = mapOf("vedtaksperiodeId" to vedtaksperiodeId),
-                dataSource = dataSource,
-                transform = Row::toForespoerselDto,
-            )
-
-    private fun hentVedtaksperiodeId(forespoerselId: UUID): UUID? =
-        "SELECT ${Db.VEDTAKSPERIODE_ID} FROM forespoersel WHERE ${Db.FORESPOERSEL_ID}=:forespoerselId"
-            .nullableResult(
-                params = mapOf("forespoerselId" to forespoerselId),
-                dataSource = dataSource,
-                transform = { Db.VEDTAKSPERIODE_ID.let(::uuid) },
-            )
 }
 
 fun Row.toForespoerselDto(): ForespoerselDto =
@@ -272,10 +291,17 @@ fun Row.toForespoerselDto(): ForespoerselDto =
 private fun Row.toBesvarelseMetadataDto(): BesvarelseMetadataDto? {
     val forespoerselBesvart = Db.FORESPOERSEL_BESVART.let(::localDateTimeOrNull)
     val inntektsmeldingId = Db.INNTEKTSMELDING_ID.let(::uuidOrNull)
+
     return forespoerselBesvart?.let { BesvarelseMetadataDto(forespoerselBesvart, inntektsmeldingId) }
 }
 
 private fun Row.toId(): Long = Db.ID.let(::long)
+
+/** Unngår bruk av ikke-transactional session. */
+private fun <T> Session.useTransaction(block: (TransactionalSession) -> T): T =
+    use { session ->
+        session.transaction(block)
+    }
 
 /** Kun brukt for å få penere kodeformat på queries fordelt over flere linjer. */
 private fun query(vararg parts: String): String = parts.joinToString(separator = " ")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
@@ -42,6 +42,7 @@ data class BesvarelseMetadataDto(
 
 enum class Status {
     AKTIV,
+    BESVART_SIMBA,
     BESVART_SPLEIS,
     FORKASTET,
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvar.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvar.kt
@@ -42,7 +42,7 @@ data class ForespoerselSvar(
             sykmeldingsperioder = forespoersel.sykmeldingsperioder,
             egenmeldingsperioder = forespoersel.egenmeldingsperioder,
             forespurtData = forespoersel.forespurtData.tilForespurtData(),
-            erBesvart = forespoersel.status in listOf(Status.BESVART_SPLEIS),
+            erBesvart = forespoersel.status in listOf(Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
         )
     }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/kafkatopic/pri/Pri.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/kafkatopic/pri/Pri.kt
@@ -42,6 +42,7 @@ object Pri {
     enum class NotisType {
         FORESPØRSEL_MOTTATT,
         FORESPOERSEL_BESVART,
+        FORESPOERSEL_BESVART_SIMBA,
         FORESPOERSEL_FORKASTET,
     }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/utils/Loggernaut.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/utils/Loggernaut.kt
@@ -12,6 +12,21 @@ class Loggernaut<T : Any>(
 
     private val seSikkerLogg = "Se sikker logg for mer info."
 
+    fun info(melding: String) {
+        aapen.info(melding)
+        sikker.info(melding)
+    }
+
+    fun warn(melding: String) {
+        aapen.warn(melding)
+        sikker.warn(melding)
+    }
+
+    fun error(melding: String) {
+        aapen.error(melding)
+        sikker.error(melding)
+    }
+
     fun ukjentFeil(feil: Throwable) {
         "Ukjent feil.".let {
             aapen.error("$it $seSikkerLogg")

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/ForkastForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/ForkastForespoerselRiverTest.kt
@@ -50,7 +50,7 @@ class ForkastForespoerselRiverTest : FunSpec({
 
         verifySequence {
             mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(vedtaksperiodeId)
-            mockForespoerselDao.oppdaterForespoerselSomForkastet(vedtaksperiodeId)
+            mockForespoerselDao.oppdaterForespoerslerSomForkastet(vedtaksperiodeId)
         }
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiverTest.kt
@@ -1,0 +1,71 @@
+package no.nav.helsearbeidsgiver.bro.sykepenger
+
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifySequence
+import kotlinx.serialization.builtins.serializer
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
+import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
+import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockForespoerselDto
+import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.sendJson
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
+import no.nav.helsearbeidsgiver.utils.json.toJson
+import java.util.UUID
+
+class MarkerBesvartFraSimbaRiverTest : FunSpec({
+    val testRapid = TestRapid()
+    val mockForespoerselDao = mockk<ForespoerselDao>(relaxed = true)
+
+    MarkerBesvartFraSimbaRiver(
+        rapid = testRapid,
+        forespoerselDao = mockForespoerselDao,
+    )
+
+    fun mockInnkommendeMelding(forespoerselId: UUID) {
+        testRapid.sendJson(
+            Pri.Key.NOTIS to Pri.NotisType.FORESPOERSEL_BESVART_SIMBA.toJson(Pri.NotisType.serializer()),
+            Pri.Key.FORESPOERSEL_ID to forespoerselId.toJson(UuidSerializer),
+        )
+    }
+
+    beforeEach {
+        clearAllMocks()
+    }
+
+    test("Innkommende event oppdaterer aktive forespørsler som er besvart") {
+        val forespoersel = mockForespoerselDto()
+
+        every {
+            mockForespoerselDao.hentForespoerselForForespoerselId(forespoersel.forespoerselId)
+        } returns forespoersel
+
+        mockInnkommendeMelding(forespoersel.forespoerselId)
+
+        verifySequence {
+            mockForespoerselDao.hentForespoerselForForespoerselId(forespoersel.forespoerselId)
+            mockForespoerselDao.oppdaterForespoerslerSomBesvartFraSimba(forespoersel.vedtaksperiodeId, any())
+        }
+    }
+
+    test("Innkommende event gjør ingenting dersom forespørsel ikke finnes") {
+        val forespoersel = mockForespoerselDto()
+
+        every {
+            mockForespoerselDao.hentForespoerselForForespoerselId(forespoersel.forespoerselId)
+        } returns null
+
+        mockInnkommendeMelding(forespoersel.forespoerselId)
+
+        verifySequence {
+            mockForespoerselDao.hentForespoerselForForespoerselId(forespoersel.forespoerselId)
+        }
+
+        verify(exactly = 0) {
+            mockForespoerselDao.oppdaterForespoerslerSomBesvartFraSimba(forespoersel.vedtaksperiodeId, any())
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiverTest.kt
@@ -32,7 +32,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
     test("Ved innkommende event, svar ut korrekt ForespoerselSvar") {
         val forespoersel = mockForespoerselDto()
 
-        every { mockForespoerselDao.hentForespoerselForForespoerselId(any(), any()) } returns forespoersel
+        every { mockForespoerselDao.hentNyesteForespoerselForForespoerselId(any(), any()) } returns forespoersel
 
         val expectedPublished =
             ForespoerselSvar(
@@ -48,7 +48,10 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
         )
 
         verifySequence {
-            mockForespoerselDao.hentForespoerselForForespoerselId(any(), setOf(Status.AKTIV, Status.BESVART_SPLEIS))
+            mockForespoerselDao.hentNyesteForespoerselForForespoerselId(
+                any(),
+                setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
+            )
             mockPriProducer.send(
                 Pri.Key.BEHOV to ForespoerselSvar.behovType.toJson(Pri.BehovType.serializer()),
                 Pri.Key.LØSNING to expectedPublished.toJson(ForespoerselSvar.serializer()),
@@ -64,7 +67,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
                 forespurtData = mockBegrensetForespurtDataListe(),
             )
 
-        every { mockForespoerselDao.hentForespoerselForForespoerselId(any(), any()) } returns forespoersel
+        every { mockForespoerselDao.hentNyesteForespoerselForForespoerselId(any(), any()) } returns forespoersel
 
         val expectedPublished =
             ForespoerselSvar(
@@ -80,7 +83,10 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
         )
 
         verifySequence {
-            mockForespoerselDao.hentForespoerselForForespoerselId(any(), setOf(Status.AKTIV, Status.BESVART_SPLEIS))
+            mockForespoerselDao.hentNyesteForespoerselForForespoerselId(
+                any(),
+                setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
+            )
             mockPriProducer.send(
                 Pri.Key.BEHOV to ForespoerselSvar.behovType.toJson(Pri.BehovType.serializer()),
                 Pri.Key.LØSNING to expectedPublished.toJson(ForespoerselSvar.serializer()),
@@ -89,7 +95,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
     }
 
     test("Når forespørsel ikke finnes skal det sendes ForespoerselSvar med error") {
-        every { mockForespoerselDao.hentForespoerselForForespoerselId(any(), any()) } returns null
+        every { mockForespoerselDao.hentNyesteForespoerselForForespoerselId(any(), any()) } returns null
 
         val forespoersel = mockForespoerselDto()
         val expectedPublished =
@@ -106,7 +112,10 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
         )
 
         verifySequence {
-            mockForespoerselDao.hentForespoerselForForespoerselId(any(), setOf(Status.AKTIV, Status.BESVART_SPLEIS))
+            mockForespoerselDao.hentNyesteForespoerselForForespoerselId(
+                any(),
+                setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
+            )
             mockPriProducer.send(
                 Pri.Key.BEHOV to ForespoerselSvar.behovType.toJson(Pri.BehovType.serializer()),
                 Pri.Key.LØSNING to expectedPublished.toJson(ForespoerselSvar.serializer()),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
@@ -33,6 +33,7 @@ import no.nav.helsearbeidsgiver.utils.test.date.juni
 import no.nav.helsearbeidsgiver.utils.test.date.november
 import java.time.LocalDateTime
 import java.util.UUID
+import kotlin.random.Random
 
 object MockUuid {
     val vedtaksperiodeId: UUID = "01234567-abcd-0123-abcd-012345678901".let(UUID::fromString)
@@ -45,8 +46,8 @@ fun mockForespoerselDto(): ForespoerselDto =
         forespoerselId = randomUuid(),
         type = Type.KOMPLETT,
         status = Status.AKTIV,
-        orgnr = "123456789".let(::Orgnr),
-        fnr = "11223344556",
+        orgnr = randomDigitString(9).let(::Orgnr),
+        fnr = randomDigitString(11),
         vedtaksperiodeId = MockUuid.vedtaksperiodeId,
         skjaeringstidspunkt = 15.januar,
         sykmeldingsperioder =
@@ -228,3 +229,7 @@ fun ForespoerselMottatt.toKeyMap() =
         Pri.Key.ORGNR to orgnr.toJson(Orgnr.serializer()),
         Pri.Key.FNR to fnr.toJson(),
     )
+
+private fun randomDigitString(length: Int): String =
+    List(length) { Random.nextInt(10) }
+        .joinToString(separator = "")


### PR DESCRIPTION
Med denne endringen vil vi kunne se hvilke forespørsler som Simba mener er besvart, men Spleis ikke mener er besvart. Spleis kan da be om nye inntektsmeldinger for disse, da de tidligere innsendte er mangelfulle eller ikke har truffet vedtaksperioden.