### PR TITLE
Fjern logging av feil som ikke er feil

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiver.kt
@@ -69,12 +69,8 @@ class MarkerBesvartFraSimbaRiver(
                     besvart = LocalDateTime.now(),
                 )
 
-            if (antallOppdaterte > 0) {
-                if (forespoersel.status == Status.AKTIV) {
-                    loggernaut.info("Oppdaterte status til besvart fra Simba for forespørsel ${forespoersel.forespoerselId}.")
-                }
-            } else {
-                loggernaut.error("Ingen forespørsler ble markert som besvart fra Simba.")
+            if (antallOppdaterte > 0 && forespoersel.status == Status.AKTIV) {
+                loggernaut.info("Oppdaterte status til besvart fra Simba for forespørsel ${forespoersel.forespoerselId}.")
             }
         } else {
             loggernaut.error("Fant ingen forespørsel å markere som besvart fra Simba.")


### PR DESCRIPTION
Det er ikke en feil dersom ingenting oppdateres. Da er det bare noen som sender inn en ny IM for en forespørsel som allerede er markert som besvart av Spleis. Denne statusen trumfer å være besvart av Simba, så vi oppdaterer ikke forespørselen.