### PR TITLE
Lag abstrakt DAO for statusrelaterte spørringer

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSpleisRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSpleisRiver.kt
@@ -94,7 +94,7 @@ class MarkerBesvartFraSpleisRiver(
             }
 
             val forespoerselIdEksponertTilSimba =
-                forespoerselDao.forespoerselIdEksponertTilSimba(
+                forespoerselDao.hentForespoerselIdEksponertTilSimba(
                     inntektsmeldingHaandtert.vedtaksperiodeId,
                 )
             if (forespoerselIdEksponertTilSimba == null) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiver.kt
@@ -85,7 +85,7 @@ class TilgjengeliggjoerForespoerselRiver(
             )
                 .let {
                     val forespoersel =
-                        forespoerselDao.hentNyesteForespoerselForForespoerselId(
+                        forespoerselDao.hentNyesteForespoerselMedBesvarelseForForespoerselId(
                             forespoerselId = it.forespoerselId,
                             statuser = setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
                         )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/DaoUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/DaoUtils.kt
@@ -1,0 +1,15 @@
+package no.nav.helsearbeidsgiver.bro.sykepenger.db
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.transaction
+
+fun <T> Transaction?.orNew(
+    db: Database,
+    statement: Transaction.() -> T,
+): T =
+    if (this != null) {
+        this.run(statement)
+    } else {
+        transaction(db, statement)
+    }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
@@ -6,26 +6,46 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.zipWithNextOrNull
-import no.nav.helsearbeidsgiver.utils.log.logger
-import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.JoinType
-import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.ResultRow
-import org.jetbrains.exposed.sql.SqlExpressionBuilder
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
-import org.jetbrains.exposed.sql.update
 import org.jetbrains.exposed.sql.upsert
 import java.time.LocalDateTime
 import java.util.UUID
 
-class ForespoerselDao(private val db: Database) {
-    private val logger = logger()
-    private val sikkerLogger = sikkerLogger()
+class ForespoerselDao(override val db: Database) : StatusDao() {
+    override val statusTable = ForespoerselTable
+
+    override fun tilForespoerselDto(row: ResultRow): ForespoerselDto {
+        val orgnr = row[ForespoerselTable.orgnr].let(::Orgnr)
+        val bestemmendeFravaersdager = row[ForespoerselTable.bestemmendeFravaersdager]
+
+        val skjaeringstidspunkt =
+            bestemmendeFravaersdager.minus(orgnr).minOfOrNull { it.value }
+                ?: row[ForespoerselTable.skjaeringstidspunkt]
+
+        return ForespoerselDto(
+            forespoerselId = row[ForespoerselTable.forespoerselId],
+            vedtaksperiodeId = row[ForespoerselTable.vedtaksperiodeId],
+            type = row[ForespoerselTable.type].let(Type::valueOf),
+            status = row[ForespoerselTable.status].let(Status::valueOf),
+            orgnr = orgnr,
+            fnr = row[ForespoerselTable.fnr],
+            egenmeldingsperioder = row[ForespoerselTable.egenmeldingsperioder],
+            sykmeldingsperioder = row[ForespoerselTable.sykmeldingsperioder],
+            skjaeringstidspunkt = skjaeringstidspunkt,
+            bestemmendeFravaersdager = bestemmendeFravaersdager,
+            forespurtData = row[ForespoerselTable.forespurtData],
+            besvarelse = tilBesvarelseMetadataDto(row),
+            opprettet = row[ForespoerselTable.opprettet],
+            oppdatert = row[ForespoerselTable.oppdatert],
+        )
+    }
 
     fun lagre(forespoersel: ForespoerselDto): Long =
         transaction(db) {
@@ -70,7 +90,7 @@ class ForespoerselDao(private val db: Database) {
                 )
 
             oppdaterteForespoersler.forEach { id ->
-                insertOrUpdateBesvarelse(id, besvart, inntektsmeldingId, this)
+                upsertBesvarelse(id, besvart, inntektsmeldingId, this)
             }
 
             oppdaterteForespoersler.size
@@ -90,21 +110,16 @@ class ForespoerselDao(private val db: Database) {
                 )
 
             oppdaterteForespoersler.forEach { id ->
-                insertOrUpdateBesvarelse(id, besvart, null, this)
+                upsertBesvarelse(id, besvart, null, this)
             }
 
             oppdaterteForespoersler.size
         }
 
-    fun oppdaterForespoerslerSomForkastet(vedtaksperiodeId: UUID) {
-        oppdaterStatuser(
-            vedtaksperiodeId = vedtaksperiodeId,
-            erstattStatuser = setOf(Status.AKTIV),
-            nyStatus = Status.FORKASTET,
-        )
-    }
-
-    fun hentForespoerselForForespoerselId(forespoerselId: UUID): ForespoerselDto? =
+    fun hentNyesteForespoerselMedBesvarelseForForespoerselId(
+        forespoerselId: UUID,
+        statuser: Set<Status>,
+    ): ForespoerselDto? =
         transaction(db) {
             ForespoerselTable.join(
                 BesvarelseTable,
@@ -114,37 +129,16 @@ class ForespoerselDao(private val db: Database) {
             )
                 .selectAll()
                 .where {
-                    ForespoerselTable.forespoerselId eq forespoerselId
+                    val vedtaksperiodeIdQuery = hentVedtaksperiodeIdQuery(forespoerselId)
+
+                    (ForespoerselTable.vedtaksperiodeId eqSubQuery vedtaksperiodeIdQuery) and
+                        (ForespoerselTable.status inList statuser.map { it.name })
                 }
                 .map(::tilForespoerselDto)
-                .firstOrNull()
-        }
-
-    fun hentNyesteForespoerselForForespoerselId(
-        forespoerselId: UUID,
-        statuser: Set<Status>,
-    ): ForespoerselDto? =
-        hentVedtaksperiodeId(forespoerselId)?.let { vedtaksperiodeId ->
-            hentForespoerslerForVedtaksperiodeId(
-                vedtaksperiodeId = vedtaksperiodeId,
-                statuser = statuser,
-            )
                 .maxByOrNull { it.opprettet }
         }
 
-    fun hentAktivForespoerselForVedtaksperiodeId(vedtaksperiodeId: UUID): ForespoerselDto? =
-        hentForespoerslerForVedtaksperiodeId(vedtaksperiodeId, setOf(Status.AKTIV))
-            .also { forespoersler ->
-                if (forespoersler.size > 1) {
-                    "Fant flere aktive forespørsler for vedtaksperiode: $vedtaksperiodeId".also {
-                        logger.error(it)
-                        sikkerLogger.error(it)
-                    }
-                }
-            }
-            .maxByOrNull { it.opprettet }
-
-    fun forespoerselIdEksponertTilSimba(vedtaksperiodeId: UUID): UUID? =
+    fun hentForespoerselIdEksponertTilSimba(vedtaksperiodeId: UUID): UUID? =
         hentForespoerslerForVedtaksperiodeId(vedtaksperiodeId, Status.entries.toSet())
             .sortedByDescending { it.opprettet }
             .zipWithNextOrNull()
@@ -154,120 +148,20 @@ class ForespoerselDao(private val db: Database) {
             ?.let { (current, _) -> current }
             ?.forespoerselId
 
-    fun hentForespoerslerForVedtaksperiodeId(
-        vedtaksperiodeId: UUID,
-        statuser: Set<Status>,
-    ): List<ForespoerselDto> =
-        transaction(db) {
-            ForespoerselTable.join(
-                BesvarelseTable,
-                JoinType.LEFT,
-                ForespoerselTable.id,
-                BesvarelseTable.fkForespoerselId,
-            )
-                .selectAll()
-                .where {
-                    (ForespoerselTable.vedtaksperiodeId eq vedtaksperiodeId) and
-                        (ForespoerselTable.status inList statuser.map { it.name })
-                }
-                .map(::tilForespoerselDto)
-                .sortedBy { it.opprettet }
-        }
-
-    private fun hentVedtaksperiodeId(forespoerselId: UUID): UUID? =
-        transaction(db) {
-            ForespoerselTable
-                .selectAll()
-                .where {
-                    ForespoerselTable.forespoerselId eq forespoerselId
-                }
-                .map {
-                    it[ForespoerselTable.vedtaksperiodeId]
-                }
-                .firstOrNull()
-        }
-
-    private fun oppdaterStatuser(
-        vedtaksperiodeId: UUID,
-        erstattStatuser: Set<Status>,
-        nyStatus: Status,
-        activeTransaction: Transaction? = null,
-    ): List<Long> {
-        val whereStatement: SqlExpressionBuilder.() -> Op<Boolean> = {
-            (ForespoerselTable.vedtaksperiodeId eq vedtaksperiodeId) and
-                (ForespoerselTable.status inList erstattStatuser.map { it.name })
-        }
-
-        return activeTransaction.orNew {
-            // Exposed støtter ikke Postgres sin RETURNING: https://github.com/JetBrains/Exposed/issues/1271
-            val updated =
-                ForespoerselTable
-                    .selectAll()
-                    .where(whereStatement)
-                    .map {
-                        it[ForespoerselTable.id]
-                    }
-
-            ForespoerselTable.update(whereStatement) {
-                it[status] = nyStatus.name
-            }
-
-            updated
-        }
-            .also {
-                val msg = "Oppdaterte ${it.size} rader med ny status '$nyStatus'. ids=$it"
-                logger.info(msg)
-                sikkerLogger.info(msg)
-            }
-    }
-
-    private fun insertOrUpdateBesvarelse(
-        forespoerselId: Long,
-        forespoerselBesvart: LocalDateTime,
+    private fun upsertBesvarelse(
+        fkForespoerselId: Long,
+        besvart: LocalDateTime,
         imId: UUID?,
-        activeTransaction: Transaction? = null,
+        activeTransaction: Transaction,
     ) {
-        activeTransaction.orNew {
+        activeTransaction.run {
             BesvarelseTable.upsert(BesvarelseTable.fkForespoerselId) {
-                it[fkForespoerselId] = forespoerselId
-                it[besvart] = forespoerselBesvart
+                it[this.fkForespoerselId] = fkForespoerselId
+                it[this.besvart] = besvart
                 it[inntektsmeldingId] = imId
             }
         }
     }
-
-    private fun <T> Transaction?.orNew(statement: Transaction.() -> T): T =
-        if (this != null) {
-            this.run(statement)
-        } else {
-            transaction(db, statement)
-        }
-}
-
-fun tilForespoerselDto(row: ResultRow): ForespoerselDto {
-    val orgnr = row[ForespoerselTable.orgnr].let(::Orgnr)
-    val bestemmendeFravaersdager = row[ForespoerselTable.bestemmendeFravaersdager]
-
-    val skjaeringstidspunkt =
-        bestemmendeFravaersdager.minus(orgnr).minOfOrNull { it.value }
-            ?: row[ForespoerselTable.skjaeringstidspunkt]
-
-    return ForespoerselDto(
-        forespoerselId = row[ForespoerselTable.forespoerselId],
-        type = row[ForespoerselTable.type].let(Type::valueOf),
-        status = row[ForespoerselTable.status].let(Status::valueOf),
-        orgnr = orgnr,
-        fnr = row[ForespoerselTable.fnr],
-        vedtaksperiodeId = row[ForespoerselTable.vedtaksperiodeId],
-        egenmeldingsperioder = row[ForespoerselTable.egenmeldingsperioder],
-        sykmeldingsperioder = row[ForespoerselTable.sykmeldingsperioder],
-        skjaeringstidspunkt = skjaeringstidspunkt,
-        bestemmendeFravaersdager = bestemmendeFravaersdager,
-        forespurtData = row[ForespoerselTable.forespurtData],
-        besvarelse = tilBesvarelseMetadataDto(row),
-        opprettet = row[ForespoerselTable.opprettet],
-        oppdatert = row[ForespoerselTable.oppdatert],
-    )
 }
 
 private fun tilBesvarelseMetadataDto(row: ResultRow): BesvarelseMetadataDto? =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/StatusDao.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/StatusDao.kt
@@ -1,0 +1,114 @@
+package no.nav.helsearbeidsgiver.bro.sykepenger.db
+
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
+import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Op
+import org.jetbrains.exposed.sql.Query
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SqlExpressionBuilder
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+import java.util.UUID
+
+abstract class StatusDao {
+    abstract val db: Database
+    abstract val statusTable: StatusTable
+
+    private val logger = logger()
+    private val sikkerLogger = sikkerLogger()
+
+    abstract fun tilForespoerselDto(row: ResultRow): ForespoerselDto
+
+    fun hentForespoerselForForespoerselId(forespoerselId: UUID): ForespoerselDto? =
+        transaction(db) {
+            statusTable
+                .selectAll()
+                .where {
+                    statusTable.forespoerselId eq forespoerselId
+                }
+                .map(::tilForespoerselDto)
+                .firstOrNull()
+        }
+
+    fun hentAktivForespoerselForVedtaksperiodeId(vedtaksperiodeId: UUID): ForespoerselDto? =
+        hentForespoerslerForVedtaksperiodeId(vedtaksperiodeId, setOf(Status.AKTIV))
+            .also { forespoersler ->
+                if (forespoersler.size > 1) {
+                    "Fant flere aktive forespørsler for vedtaksperiode: $vedtaksperiodeId".also {
+                        logger.error(it)
+                        sikkerLogger.error(it)
+                    }
+                }
+            }
+            .maxByOrNull { it.opprettet }
+
+    fun hentForespoerslerForVedtaksperiodeId(
+        vedtaksperiodeId: UUID,
+        statuser: Set<Status>,
+    ): List<ForespoerselDto> =
+        transaction(db) {
+            statusTable
+                .selectAll()
+                .where {
+                    (statusTable.vedtaksperiodeId eq vedtaksperiodeId) and
+                        (statusTable.status inList statuser.map { it.name })
+                }
+                .map(::tilForespoerselDto)
+                .sortedBy { it.opprettet }
+        }
+
+    protected fun hentVedtaksperiodeIdQuery(forespoerselId: UUID): Query =
+        statusTable
+            .select(statusTable.vedtaksperiodeId)
+            .where {
+                statusTable.forespoerselId eq forespoerselId
+            }
+
+    fun oppdaterForespoerslerSomForkastet(vedtaksperiodeId: UUID) {
+        oppdaterStatuser(
+            vedtaksperiodeId = vedtaksperiodeId,
+            erstattStatuser = setOf(Status.AKTIV),
+            nyStatus = Status.FORKASTET,
+        )
+    }
+
+    protected fun oppdaterStatuser(
+        vedtaksperiodeId: UUID,
+        erstattStatuser: Set<Status>,
+        nyStatus: Status,
+        activeTransaction: Transaction? = null,
+    ): List<Long> {
+        val whereStatement: SqlExpressionBuilder.() -> Op<Boolean> = {
+            (statusTable.vedtaksperiodeId eq vedtaksperiodeId) and
+                (statusTable.status inList erstattStatuser.map { it.name })
+        }
+
+        return activeTransaction.orNew(db) {
+            // Exposed støtter ikke Postgres sin RETURNING: https://github.com/JetBrains/Exposed/issues/1271
+            val updated =
+                statusTable
+                    .selectAll()
+                    .where(whereStatement)
+                    .map {
+                        it[statusTable.id]
+                    }
+
+            statusTable.update(whereStatement) {
+                it[status] = nyStatus.name
+            }
+
+            updated
+        }
+            .also {
+                val msg = "Oppdaterte ${it.size} rader med ny status '$nyStatus'. ids=$it"
+                logger.info(msg)
+                sikkerLogger.info(msg)
+            }
+    }
+}

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/Tables.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/Tables.kt
@@ -7,24 +7,32 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.javatime.date
 import org.jetbrains.exposed.sql.javatime.datetime
 import org.jetbrains.exposed.sql.json.jsonb
+import java.util.UUID
 
-object ForespoerselTable : Table("forespoersel") {
-    val id =
+abstract class StatusTable(name: String) : Table(name) {
+    abstract val id: Column<Long>
+    abstract val forespoerselId: Column<UUID>
+    abstract val vedtaksperiodeId: Column<UUID>
+    abstract val status: Column<String>
+}
+
+object ForespoerselTable : StatusTable("forespoersel") {
+    override val id =
         long("id").autoIncrement(
             idSeqName = "forespoersel_id_seq",
         )
-    val forespoerselId = uuid("forespoersel_id")
+    override val forespoerselId = uuid("forespoersel_id")
+    override val vedtaksperiodeId = uuid("vedtaksperiode_id")
+    override val status = varchar("status", 50)
 
-    // Denne er varchar av udefinert lengde i databasen
     val type = text("type")
-    val status = varchar("status", 50)
     val orgnr = varchar("orgnr", 50)
     val fnr = varchar("fnr", 50)
-    val vedtaksperiodeId = uuid("vedtaksperiode_id")
     val egenmeldingsperioder = jsonb("egenmeldingsperioder", jsonConfig, Periode.serializer().list())
     val sykmeldingsperioder = jsonb("sykmeldingsperioder", jsonConfig, Periode.serializer().list())
     val skjaeringstidspunkt = date("skjaeringstidspunkt").nullable()

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiverTest.kt
@@ -6,7 +6,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
-import kotlinx.serialization.builtins.serializer
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSpleisRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSpleisRiverTest.kt
@@ -60,7 +60,7 @@ class MarkerBesvartFraSpleisRiverTest : FunSpec({
                 inntektsmeldingHaandtert.haandtert,
                 inntektsmeldingHaandtert.inntektsmeldingId,
             )
-            mockForespoerselDao.forespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
+            mockForespoerselDao.hentForespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
         }
     }
 
@@ -78,7 +78,7 @@ class MarkerBesvartFraSpleisRiverTest : FunSpec({
                 inntektsmeldingHaandtert.haandtert,
                 inntektsmeldingHaandtert.inntektsmeldingId,
             )
-            mockForespoerselDao.forespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
+            mockForespoerselDao.hentForespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
         }
     }
 
@@ -89,7 +89,7 @@ class MarkerBesvartFraSpleisRiverTest : FunSpec({
         every { mockForespoerselDao.oppdaterForespoerslerSomBesvartFraSpleis(any(), any(), any()) } returns 1
 
         every {
-            mockForespoerselDao.forespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
+            mockForespoerselDao.hentForespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
         } returns expectedForespoerselId
 
         mockInnkommendeMelding(inntektsmeldingHaandtert)
@@ -127,7 +127,7 @@ class MarkerBesvartFraSpleisRiverTest : FunSpec({
         } returns 1
 
         every {
-            mockForespoerselDao.forespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
+            mockForespoerselDao.hentForespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
         } returns expectedForespoerselId
 
         mockInnkommendeMelding(inntektsmeldingHaandtert)
@@ -153,7 +153,7 @@ class MarkerBesvartFraSpleisRiverTest : FunSpec({
         } returns 1
 
         every {
-            mockForespoerselDao.forespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
+            mockForespoerselDao.hentForespoerselIdEksponertTilSimba(inntektsmeldingHaandtert.vedtaksperiodeId)
         } returns expectedForespoerselId
 
         mockInnkommendeMelding(inntektsmeldingHaandtert)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/TilgjengeliggjoerForespoerselRiverTest.kt
@@ -32,7 +32,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
     test("Ved innkommende event, svar ut korrekt ForespoerselSvar") {
         val forespoersel = mockForespoerselDto()
 
-        every { mockForespoerselDao.hentNyesteForespoerselForForespoerselId(any(), any()) } returns forespoersel
+        every { mockForespoerselDao.hentNyesteForespoerselMedBesvarelseForForespoerselId(any(), any()) } returns forespoersel
 
         val expectedPublished =
             ForespoerselSvar(
@@ -48,7 +48,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
         )
 
         verifySequence {
-            mockForespoerselDao.hentNyesteForespoerselForForespoerselId(
+            mockForespoerselDao.hentNyesteForespoerselMedBesvarelseForForespoerselId(
                 any(),
                 setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
             )
@@ -67,7 +67,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
                 forespurtData = mockBegrensetForespurtDataListe(),
             )
 
-        every { mockForespoerselDao.hentNyesteForespoerselForForespoerselId(any(), any()) } returns forespoersel
+        every { mockForespoerselDao.hentNyesteForespoerselMedBesvarelseForForespoerselId(any(), any()) } returns forespoersel
 
         val expectedPublished =
             ForespoerselSvar(
@@ -83,7 +83,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
         )
 
         verifySequence {
-            mockForespoerselDao.hentNyesteForespoerselForForespoerselId(
+            mockForespoerselDao.hentNyesteForespoerselMedBesvarelseForForespoerselId(
                 any(),
                 setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
             )
@@ -95,7 +95,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
     }
 
     test("Når forespørsel ikke finnes skal det sendes ForespoerselSvar med error") {
-        every { mockForespoerselDao.hentNyesteForespoerselForForespoerselId(any(), any()) } returns null
+        every { mockForespoerselDao.hentNyesteForespoerselMedBesvarelseForForespoerselId(any(), any()) } returns null
 
         val forespoersel = mockForespoerselDto()
         val expectedPublished =
@@ -112,7 +112,7 @@ class TilgjengeliggjoerForespoerselRiverTest : FunSpec({
         )
 
         verifySequence {
-            mockForespoerselDao.hentNyesteForespoerselForForespoerselId(
+            mockForespoerselDao.hentNyesteForespoerselMedBesvarelseForForespoerselId(
                 any(),
                 setOf(Status.AKTIV, Status.BESVART_SIMBA, Status.BESVART_SPLEIS),
             )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/StatusDaoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/StatusDaoTest.kt
@@ -1,0 +1,262 @@
+package no.nav.helsearbeidsgiver.bro.sykepenger.db
+
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Orgnr
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
+import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.MockUuid
+import no.nav.helsearbeidsgiver.bro.sykepenger.utils.randomUuid
+import no.nav.helsearbeidsgiver.utils.test.date.kl
+import no.nav.helsearbeidsgiver.utils.test.date.mai
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.javatime.datetime
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.util.UUID
+
+object TestTable : StatusTable("status") {
+    override val id =
+        long("id").autoIncrement(
+            idSeqName = "status_id_seq",
+        )
+    override val forespoerselId = uuid("forespoersel_id")
+    override val vedtaksperiodeId = uuid("vedtaksperiode_id")
+    override val status = text("status")
+    val opprettet = datetime("opprettet")
+}
+
+class TestDao(override val db: Database) : StatusDao() {
+    override val statusTable = TestTable
+
+    override fun tilForespoerselDto(row: ResultRow): ForespoerselDto =
+        mockForespoerselDto().copy(
+            forespoerselId = row[TestTable.forespoerselId],
+            vedtaksperiodeId = row[TestTable.vedtaksperiodeId],
+            status = row[TestTable.status].let(Status::valueOf),
+            opprettet = row[TestTable.opprettet],
+        )
+
+    fun lagre(forespoersel: ForespoerselDto): Long =
+        transaction(db) {
+            TestTable.insert {
+                it[forespoerselId] = forespoersel.forespoerselId
+                it[vedtaksperiodeId] = forespoersel.vedtaksperiodeId
+                it[status] = forespoersel.status.name
+                it[opprettet] = forespoersel.opprettet
+            }
+                .let {
+                    it[TestTable.id]
+                }
+        }
+
+    fun hentForespoersel(id: Long): ForespoerselDto =
+        transaction(db) {
+            TestTable
+                .selectAll()
+                .where {
+                    TestTable.id eq id
+                }
+                .firstOrNull()
+        }
+            .shouldNotBeNull()
+            .let(::tilForespoerselDto)
+}
+
+class GenericDaoTest : FunSpecWithDb(listOf(TestTable), { db ->
+    val testDao = TestDao(db)
+
+    context(StatusDao::hentForespoerselForForespoerselId.name) {
+        test("Hent ønsket forespørsel") {
+            val expected = mockForespoerselDto()
+
+            testDao.lagre(mockForespoerselDto())
+            testDao.lagre(expected)
+            testDao.lagre(mockForespoerselDto())
+
+            val actual = testDao.hentForespoerselForForespoerselId(expected.forespoerselId)
+
+            actual.shouldNotBeNull()
+            actual shouldBe expected
+        }
+
+        test("Gi 'null' dersom ingen forespørsel finnes") {
+            testDao.hentForespoerselForForespoerselId(randomUuid()) shouldBe null
+        }
+    }
+
+    context(StatusDao::hentAktivForespoerselForVedtaksperiodeId.name) {
+        test("Henter eneste aktive forespørsel i databasen knyttet til en vedtaksperiodeId") {
+            val forkastetForespoersel =
+                mockForespoerselDto()
+                    .copy(status = Status.FORKASTET)
+                    .also(testDao::lagre)
+
+            val aktivForespoersel = mockForespoerselDto().also(testDao::lagre)
+
+            // Skal ikke bli plukket opp pga. annerledes vedtaksperiode-ID
+            mockForespoerselDto()
+                .copy(vedtaksperiodeId = randomUuid())
+                .let(testDao::lagre)
+
+            val actualForespoersel = testDao.hentAktivForespoerselForVedtaksperiodeId(forkastetForespoersel.vedtaksperiodeId)
+
+            actualForespoersel.shouldNotBeNull()
+            actualForespoersel shouldBe aktivForespoersel
+        }
+
+        test("Skal returnere siste aktive forespørsel dersom det er flere (skal ikke skje)") {
+            val gammelForespoersel = mockForespoerselDto().also(testDao::lagre)
+            val nyForespoersel = mockForespoerselDto().oekOpprettet(1).also(testDao::lagre)
+
+            // Skal ikke bli plukket opp pga. annerledes vedtaksperiode-ID
+            mockForespoerselDto()
+                .copy(vedtaksperiodeId = randomUuid())
+                .let(testDao::lagre)
+
+            val actualForespoersel = testDao.hentAktivForespoerselForVedtaksperiodeId(gammelForespoersel.vedtaksperiodeId)
+
+            actualForespoersel.shouldNotBeNull()
+            actualForespoersel shouldBe nyForespoersel
+        }
+
+        test("Skal returnere 'null' dersom ingen matchende forespørsler finnes") {
+            testDao.lagre(
+                mockForespoerselDto().copy(vedtaksperiodeId = randomUuid()),
+            )
+
+            db.antallForespoersler() shouldBeExactly 1
+
+            testDao.hentAktivForespoerselForVedtaksperiodeId(MockUuid.vedtaksperiodeId)
+                .shouldBeNull()
+        }
+
+        test("Skal returnere 'null' dersom ingen av forespørslene er aktive") {
+            testDao.lagre(
+                mockForespoerselDto().copy(status = Status.FORKASTET),
+            )
+
+            testDao.lagre(
+                mockForespoerselDto().copy(status = Status.BESVART_SPLEIS),
+            )
+
+            db.antallForespoersler() shouldBeExactly 2
+
+            testDao.hentAktivForespoerselForVedtaksperiodeId(MockUuid.vedtaksperiodeId)
+                .shouldBeNull()
+        }
+    }
+
+    context(StatusDao::hentForespoerslerForVedtaksperiodeId.name) {
+
+        test("Henter alle forespørsler knyttet til en vedtaksperiodeId") {
+            val a = mockForespoerselDto().copy(status = Status.FORKASTET)
+            val b = mockForespoerselDto().copy(status = Status.BESVART_SPLEIS).oekOpprettet(1)
+            val c = mockForespoerselDto().oekOpprettet(2)
+
+            listOf(a, b, c).forEach(testDao::lagre)
+
+            val actual =
+                testDao.hentForespoerslerForVedtaksperiodeId(
+                    vedtaksperiodeId = MockUuid.vedtaksperiodeId,
+                    statuser = Status.entries.toSet(),
+                )
+
+            actual shouldHaveSize 3
+
+            actual[0] shouldBe a
+            actual[1] shouldBe b
+            actual[2] shouldBe c
+        }
+
+        test("Henter forespørsler med gitt status som er knyttet til en vedtaksperiodeId") {
+            val a = mockForespoerselDto().copy(status = Status.FORKASTET)
+            val b = mockForespoerselDto().copy(status = Status.BESVART_SPLEIS).oekOpprettet(1)
+            val c = mockForespoerselDto().copy(status = Status.BESVART_SPLEIS).oekOpprettet(2)
+            val d = mockForespoerselDto().oekOpprettet(3)
+
+            listOf(a, b, c, d).forEach(testDao::lagre)
+
+            val actual =
+                testDao.hentForespoerslerForVedtaksperiodeId(
+                    vedtaksperiodeId = MockUuid.vedtaksperiodeId,
+                    statuser = setOf(Status.BESVART_SPLEIS),
+                )
+
+            actual shouldHaveSize 2
+
+            actual[0] shouldBe b
+            actual[1] shouldBe c
+        }
+    }
+
+    context(StatusDao::oppdaterForespoerslerSomForkastet.name) {
+
+        test("Oppdaterer aktiv forespørsel til forkastet") {
+            val id = testDao.lagre(mockForespoerselDto())
+
+            testDao.oppdaterForespoerslerSomForkastet(MockUuid.vedtaksperiodeId)
+
+            val forespoersel = testDao.hentForespoersel(id)
+
+            forespoersel.status shouldBe Status.FORKASTET
+        }
+
+        test("Oppdaterer ikke besvart fra Simba til forkastet") {
+            val id =
+                testDao.lagre(
+                    mockForespoerselDto().copy(status = Status.BESVART_SIMBA),
+                )
+
+            testDao.oppdaterForespoerslerSomForkastet(MockUuid.vedtaksperiodeId)
+
+            val forespoersel = testDao.hentForespoersel(id)
+
+            forespoersel.status shouldBe Status.BESVART_SIMBA
+        }
+
+        test("Oppdaterer ikke besvart fra Spleis til forkastet") {
+            val id =
+                testDao.lagre(
+                    mockForespoerselDto().copy(status = Status.BESVART_SPLEIS),
+                )
+
+            testDao.oppdaterForespoerslerSomForkastet(MockUuid.vedtaksperiodeId)
+
+            val forespoersel = testDao.hentForespoersel(id)
+
+            forespoersel.status shouldBe Status.BESVART_SPLEIS
+        }
+    }
+})
+
+private fun Database.antallForespoersler(): Int =
+    transaction(this) {
+        TestTable.selectAll().count()
+    }.toInt()
+
+private fun ForespoerselDto.oekOpprettet(sekunder: Long): ForespoerselDto = copy(opprettet = opprettet.plusSeconds(sekunder))
+
+private fun mockForespoerselDto(): ForespoerselDto =
+    ForespoerselDto(
+        forespoerselId = UUID.randomUUID(),
+        vedtaksperiodeId = MockUuid.vedtaksperiodeId,
+        type = Type.KOMPLETT,
+        status = Status.AKTIV,
+        orgnr = "888444888".let(::Orgnr),
+        fnr = "fnr",
+        egenmeldingsperioder = emptyList(),
+        sykmeldingsperioder = emptyList(),
+        skjaeringstidspunkt = null,
+        bestemmendeFravaersdager = emptyMap(),
+        forespurtData = emptyList(),
+        besvarelse = null,
+        opprettet = 6.mai.kl(16, 43, 15, 0),
+        oppdatert = 6.mai.kl(17, 44, 16, 1),
+    )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/StatusDaoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/StatusDaoTest.kt
@@ -69,7 +69,7 @@ class TestDao(override val db: Database) : StatusDao() {
             .let(::tilForespoerselDto)
 }
 
-class GenericDaoTest : FunSpecWithDb(listOf(TestTable), { db ->
+class StatusDaoTest : FunSpecWithDb(listOf(TestTable), { db ->
     val testDao = TestDao(db)
 
     context(StatusDao::hentForespoerselForForespoerselId.name) {

--- a/src/test/resources/db/migration/V99__create_table_status.sql
+++ b/src/test/resources/db/migration/V99__create_table_status.sql
@@ -1,0 +1,8 @@
+CREATE TABLE status
+(
+    id                BIGSERIAL PRIMARY KEY,
+    forespoersel_id   UUID UNIQUE NOT NULL,
+    vedtaksperiode_id UUID        NOT NULL,
+    status            TEXT        NOT NULL,
+    opprettet         TIMESTAMP   NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
Denne PR-en er en forberedelse til lagring av potensielle forespørsler. Oppførselen til statusfeltet i potensielle forespørsler vil være likt dagens, så da abstraherer jeg ut den koden slik at den også kan brukes av en annen DAO. 