### PR TITLE
Preprod/exposed logging

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/App.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/App.kt
@@ -12,6 +12,8 @@ fun main() {
     broLogger.info("Hello bro!")
 
     "Exposed".logger().warn("Exposed logger")
+    "Exposed".logger().info("Exposed logger")
+    "Exposed".logger().error("Exposed logger")
 
     val forespoerselDao = ForespoerselDao(Database.db)
     val priProducer = PriProducer()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/App.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/App.kt
@@ -11,6 +11,8 @@ fun main() {
     val broLogger = "BroLogger".logger()
     broLogger.info("Hello bro!")
 
+    "Exposed".logger().warn("Exposed logger")
+
     val forespoerselDao = ForespoerselDao(Database.db)
     val priProducer = PriProducer()
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/App.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/App.kt
@@ -11,10 +11,6 @@ fun main() {
     val broLogger = "BroLogger".logger()
     broLogger.info("Hello bro!")
 
-    "Exposed".logger().warn("Exposed logger")
-    "Exposed".logger().info("Exposed logger")
-    "Exposed".logger().error("Exposed logger")
-
     val forespoerselDao = ForespoerselDao(Database.db)
     val priProducer = PriProducer()
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+
+    <appender name="secureLog" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/secure-logs/secure.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/secure-logs/secure.log.%i</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>1</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>50MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+    </appender>
+    <logger name="no.nav.helse.rapids_rivers" level="DEBUG" />
+
+    <logger name="tjenestekall" level="DEBUG" additivity="false">
+        <appender-ref ref="secureLog" />
+    </logger>
+    <logger  name="Exposed" level="WARN" additivity="false">
+        <appender-ref ref="secureLog"/>
+    </logger>
+    <logger name="org.jetbrains.exposed" level="WARN" additivity="false">
+        <appender-ref ref="secureLog"/>
+    </logger>
+    <root level="INFO">
+        <appender-ref ref="STDOUT_JSON"/>
+    </root>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -21,6 +21,7 @@
     <logger name="tjenestekall" level="DEBUG" additivity="false">
         <appender-ref ref="secureLog" />
     </logger>
+    // Ikke slett! Denne ble lagt til siden Exposed loggeren ikke logget til secureLog og logget parameterverdier når det feilet i databasetransaksjoner.
     <logger  name="Exposed" level="WARN" additivity="false">
         <appender-ref ref="secureLog"/>
     </logger>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -21,9 +21,8 @@
     <logger name="tjenestekall" level="DEBUG" additivity="false">
         <appender-ref ref="secureLog" />
     </logger>
-    <logger  name="Exposed" level="WARN" additivity="false">
-        <appender-ref ref="secureLog"/>
-    </logger>
+
+
     <logger name="org.jetbrains.exposed" level="WARN" additivity="false">
         <appender-ref ref="secureLog"/>
     </logger>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -16,8 +16,8 @@
         </triggeringPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
-    <logger name="no.nav.helse.rapids_rivers" level="DEBUG" />
 
+    <logger name="no.nav.helse.rapids_rivers" level="DEBUG" />
     <logger name="tjenestekall" level="DEBUG" additivity="false">
         <appender-ref ref="secureLog" />
     </logger>
@@ -27,6 +27,7 @@
     <logger name="org.jetbrains.exposed" level="INFO" additivity="false">
         <appender-ref ref="secureLog"/>
     </logger>
+
     <root level="INFO">
         <appender-ref ref="STDOUT_JSON"/>
     </root>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -24,7 +24,7 @@
     <logger  name="Exposed" level="WARN" additivity="false">
         <appender-ref ref="secureLog"/>
     </logger>
-    <logger name="org.jetbrains.exposed" level="WARN" additivity="false">
+    <logger name="org.jetbrains.exposed" level="INFO" additivity="false">
         <appender-ref ref="secureLog"/>
     </logger>
     <root level="INFO">

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -21,8 +21,9 @@
     <logger name="tjenestekall" level="DEBUG" additivity="false">
         <appender-ref ref="secureLog" />
     </logger>
-
-
+    <logger  name="Exposed" level="WARN" additivity="false">
+        <appender-ref ref="secureLog"/>
+    </logger>
     <logger name="org.jetbrains.exposed" level="WARN" additivity="false">
         <appender-ref ref="secureLog"/>
     </logger>


### PR DESCRIPTION
Lagt inn logback.xml som overskriver logback.xml i rapids rivers biblioteket. Det er også lagt in en logger ved start av applikasjonen for å teste at Exposed blir logger i secure-logger.