### PR TITLE
Logg forskjeller i utledet og foreslått bestemmende fraværsdag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,7 @@ repositories {
 dependencies {
     val exposedVersion: String by project
     val flywayCoreVersion: String by project
+    val hagDomeneInntektsmeldingVersion: String by project
     val hikariVersion: String by project
     val kotestVersion: String by project
     val kotlinxSerializationVersion: String by project
@@ -81,6 +82,7 @@ dependencies {
     implementation("com.github.navikt:rapids-and-rivers:$rapidsAndRiversVersion")
     implementation("com.zaxxer:HikariCP:$hikariVersion")
     implementation("io.ktor:ktor-client-core:$ktorVersion")
+    implementation("no.nav.helsearbeidsgiver:domene-inntektsmelding:$hagDomeneInntektsmeldingVersion")
     implementation("no.nav.helsearbeidsgiver:utils:$utilsVersion")
     implementation("org.flywaydb:flyway-core:$flywayCoreVersion")
     implementation("org.flywaydb:flyway-database-postgresql:$flywayCoreVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ kotlinterVersion=4.2.0
 # Dependency versions
 exposedVersion=0.47.0
 flywayCoreVersion=10.8.1
+hagDomeneInntektsmeldingVersion=0.1.5
 hikariVersion=5.1.0
 kotestVersion=5.8.0
 kotlinxSerializationVersion=1.6.3

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
@@ -19,11 +19,14 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.utils.demandValues
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.les
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.require
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.requireKeys
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import java.util.UUID
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode as PeriodeV1
 
 class LagreKomplettForespoerselRiver(
     rapid: RapidsConnection,
@@ -67,19 +70,41 @@ class LagreKomplettForespoerselRiver(
         val bestemmendeFravaersdager =
             Spleis.Key.BESTEMMENDE_FRAVÆRSDAGER.les(bestemmendeFravaersdagerSerializer, melding)
 
-        return ForespoerselDto(
-            forespoerselId = forespoerselId,
-            type = Type.KOMPLETT,
-            status = Status.AKTIV,
-            orgnr = orgnr,
-            fnr = Spleis.Key.FØDSELSNUMMER.les(String.serializer(), melding),
-            vedtaksperiodeId = Spleis.Key.VEDTAKSPERIODE_ID.les(UuidSerializer, melding),
-            egenmeldingsperioder = Spleis.Key.EGENMELDINGSPERIODER.les(Periode.serializer().list(), melding),
-            sykmeldingsperioder = Spleis.Key.SYKMELDINGSPERIODER.les(Periode.serializer().list(), melding),
-            skjaeringstidspunkt = null,
-            bestemmendeFravaersdager = bestemmendeFravaersdager,
-            forespurtData = Spleis.Key.FORESPURT_DATA.les(SpleisForespurtDataDto.serializer().list(), melding),
-            besvarelse = null,
-        )
+        val forespoersel =
+            ForespoerselDto(
+                forespoerselId = forespoerselId,
+                type = Type.KOMPLETT,
+                status = Status.AKTIV,
+                orgnr = orgnr,
+                fnr = Spleis.Key.FØDSELSNUMMER.les(String.serializer(), melding),
+                vedtaksperiodeId = Spleis.Key.VEDTAKSPERIODE_ID.les(UuidSerializer, melding),
+                egenmeldingsperioder = Spleis.Key.EGENMELDINGSPERIODER.les(Periode.serializer().list(), melding),
+                sykmeldingsperioder = Spleis.Key.SYKMELDINGSPERIODER.les(Periode.serializer().list(), melding),
+                skjaeringstidspunkt = null,
+                bestemmendeFravaersdager = bestemmendeFravaersdager,
+                forespurtData = Spleis.Key.FORESPURT_DATA.les(SpleisForespurtDataDto.serializer().list(), melding),
+                besvarelse = null,
+            )
+
+        val bf =
+            bestemmendeFravaersdag(
+                arbeidsgiverperioder = emptyList(),
+                sykefravaersperioder = forespoersel.sykmeldingsperioder.map { PeriodeV1(it.fom, it.tom) },
+            )
+        if (
+            forespoersel.bestemmendeFravaersdager.size == 1 &&
+            forespoersel.bestemmendeFravaersdager.values.first() != bf
+        ) {
+            MdcUtils.withLogFields(
+                "forspoerselId" to forespoersel.forespoerselId.toString(),
+            ) {
+                loggernaut.sikker.info(
+                    "Forslag fra Spleis (${forespoersel.bestemmendeFravaersdager.values.first()}) " +
+                        "matcher ikke utledet bestemmende fraværsdag fra sykmeldingsperioder ($bf, uten egenmld).",
+                )
+            }
+        }
+
+        return forespoersel
     }
 }


### PR DESCRIPTION
Sykmeldtes rapporterte egenmeldinger er ikke lenger tatt med i Spleis sitt forslag til bestemmende fraværsdag (BF). Det har ført til endringer i Simba, som igjen har ført til diskusjoner om potensielle fallgruver for de nye endringene. Vi ønsker nå å logge forskjeller mellom utledet og forslått BF for å se i hvilke tilfeller det oppstår i. Én teori er at det aldri skjer (eksludert flere arbeidsgivere), og da vanker det forenklinger i måten vi håndterer BF. Tiden vil vise.