### PR TITLE
Legg til databasetier i config

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -51,6 +51,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-f1-micro
         databases:
           - name: helsearbeidsgiver-bro-sykepenger
             users:

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -50,6 +50,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: db-f1-micro
         databases:
           - name: helsearbeidsgiver-bro-sykepenger
             users:


### PR DESCRIPTION
Eksplisitt databasetier har blitt påkrevd siden forrige deploy. Bruker tidligere default til å begynne med, så kan vi oppgradere når vi tåler noe nedetid.