### PR TITLE
Fjern utdatert felt for besvarelse

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiver.kt
@@ -67,6 +67,5 @@ class LagreBegrensetForespoerselRiver(
             sykmeldingsperioder = Spleis.Key.SYKMELDINGSPERIODER.les(Periode.serializer().list(), melding),
             bestemmendeFravaersdager = emptyMap(),
             forespurtData = Spleis.Key.FORESPURT_DATA.les(SpleisForespurtDataDto.serializer().list(), melding),
-            besvarelse = null,
         )
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
@@ -83,7 +83,6 @@ class LagreKomplettForespoerselRiver(
                 sykmeldingsperioder = Spleis.Key.SYKMELDINGSPERIODER.les(Periode.serializer().list(), melding),
                 bestemmendeFravaersdager = bestemmendeFravaersdager,
                 forespurtData = Spleis.Key.FORESPURT_DATA.les(SpleisForespurtDataDto.serializer().list(), melding),
-                besvarelse = null,
             )
 
         val bfUtenEgenmld =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/Tables.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/Tables.kt
@@ -35,7 +35,7 @@ object ForespoerselTable : Table("forespoersel") {
 }
 
 object BesvarelseTable : Table("besvarelse_metadata") {
-    val id =
+    private val id =
         integer("id").autoIncrement(
             idSeqName = "besvarelse_metadata_id_seq",
         )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
@@ -21,7 +21,6 @@ data class ForespoerselDto(
     val sykmeldingsperioder: List<Periode>,
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: List<SpleisForespurtDataDto>,
-    val besvarelse: BesvarelseMetadataDto?,
     val opprettet: LocalDateTime = LocalDateTime.now().truncMillis(),
     val oppdatert: LocalDateTime = LocalDateTime.now().truncMillis(),
 ) {
@@ -29,16 +28,10 @@ data class ForespoerselDto(
         this ==
             other.copy(
                 forespoerselId = forespoerselId,
-                besvarelse = besvarelse,
                 opprettet = opprettet,
                 oppdatert = oppdatert,
             )
 }
-
-data class BesvarelseMetadataDto(
-    val forespoerselBesvart: LocalDateTime,
-    val inntektsmeldingId: UUID?,
-)
 
 enum class Status {
     AKTIV,
@@ -62,14 +55,6 @@ enum class Type {
      *   - mangler bestemmende fraværsdager
      */
     BEGRENSET,
-
-    /**
-     * En potensiell forespørsel er knyttet til en vedtaksperiode som er innenfor arbeidsgiverperioden.
-     *
-     * Slike perioder trenger ingen arbeidsgiveropplysninger, men skal tillate å motta opplysninger fra arbeidsgiver
-     * fordi de kan ha opplysninger som gjør at perioden strekker seg forbi arbeidsgiverperioden.
-     */
-    POTENSIELL,
 }
 
 @Serializable

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDtoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDtoTest.kt
@@ -17,9 +17,6 @@ class ForespoerselDtoTest :
                 mapOf<String, (ForespoerselDto) -> ForespoerselDto>(
                     "Aksepterer helt like" to { it },
                     "Ignorerer 'forespoerselId'" to { it.copy(forespoerselId = UUID.randomUUID()) },
-                    "Ignorerer 'besvarelse'" to {
-                        it.copy(besvarelse = BesvarelseMetadataDto(LocalDateTime.now(), UUID.randomUUID()))
-                    },
                     "Ignorerer 'opprettet'" to { it.copy(opprettet = LocalDateTime.now().minusDays(5)) },
                     "Ignorerer 'oppdatert'" to { it.copy(oppdatert = LocalDateTime.now().plusDays(10)) },
                 ),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
@@ -64,7 +64,6 @@ fun mockForespoerselDto(): ForespoerselDto {
                 "678678678".let(::Orgnr) to 19.januar,
             ),
         forespurtData = mockSpleisForespurtDataListe(),
-        besvarelse = null,
     )
 }
 


### PR DESCRIPTION
Besvarelse blir fremdeles lagret i databasen, men det brukes ikke i koden og trengs dermed ikke leses. Da slipper vi noen joins, som bør gi litt kjappere spørringer.

Besvarelsene brukes fremdeles av dataproduktene, så vi vil fremdeles lagre dem.