### PR TITLE
Oppdater gradle-actions i workflows

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,10 +16,8 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test
         run: ./gradlew build test

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,17 +20,12 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Run snapshot action
-        uses: mikepenz/gradle-dependency-submission@v1
-        with:
-          gradle-build-configuration: |-
-            compileClasspath
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,6 @@ on:
       - preprod/**
       - dev/**
 
-env:
-  TEAM: helsearbeidsgiver
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,15 +22,11 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: build test jar --console=plain
+        run: ./gradlew build test jar --console=plain
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,16 +34,9 @@ jobs:
         uses: nais/docker-build-push@v0
         id: docker_push
         with:
-          team: ${{ env.TEAM }}
+          team: helsearbeidsgiver
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
-
-      - name: Cleanup Gradle Cache
-        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
-        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
-        run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
 
   deploy-to-dev:
     name: Deploy to dev-gcp

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [released]
 
-env:
-  TEAM: helsearbeidsgiver
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,26 +19,19 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: build test jar --console=plain
+        run: ./gradlew build test jar --console=plain
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Build and push docker image
         uses: nais/docker-build-push@v0
         id: docker_push
         with:
-          team: ${{ env.TEAM }}
+          team: helsearbeidsgiver
           project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
           identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
 


### PR DESCRIPTION
Bumper `setup-gradle` fra v3 til v4. Det medfører at
- `with.cache: gradle` fjernes fra `setup-java`, som beskrevet [her](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms)
- `wrapper-validation-action` fjernes som steg fordi det er innebygget i `setup-gradle@v4`, som beskrevet [her](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation)
- `with.arguments` fjernes fra `setup-gradle` og erstattes med eget steg, som beskrevet [her](https://github.com/gradle/actions/releases/tag/v4.0.0)

Fjerner `mikepenz/gradle-dependency-submission` ([utdatert](https://github.com/mikepenz/gradle-dependency-submission)) til fordel for `gradle/actions/dependency-submission@v4`, som er beskrevet [her](https://github.com/gradle/actions/blob/main/docs/dependency-submission.md)