### PR TITLE
Skrur cpu ned, replicas opp, og autoinstrumentering på

### DIFF
--- a/deploy/nais.yml
+++ b/deploy/nais.yml
@@ -10,13 +10,13 @@ spec:
   image: {{ image }}
   resources:
     requests:
-      cpu: 200m
+      cpu: 50m
       memory: 512Mi
     limits:
       memory: 1024Mi
   replicas:
-    max: 1
-    min: 1
+    max: 2
+    min: 2
   liveness:
     path: isalive
     initialDelay: 10
@@ -31,6 +31,10 @@ spec:
     enabled: true
   prometheus:
     enabled: true
+  observability:
+    autoInstrumentation:
+      enabled: true
+      runtime: java
   gcp:
     sqlInstances:
       - type: POSTGRES_14


### PR DESCRIPTION
Appen har aldri trengt 200 mCPU, ref. https://console.nav.cloud.nais.io/team/helsearbeidsgiver/prod-gcp/app/helsearbeidsgiver-bro-sykepenger/utilization?interval=30d.

\>1 replicas gjør at vi slipper nedetid dersom appen oppdateres av noen utenfor teamet (typisk nais). Vi må holde et lite øye på databasen i dev, som kjører på billigste tier og derfor kun tåler 20 connections.

Autoinstrumentering gir oss mange muligheter for innsikt.