### PR TITLE
Øk minne (pga. autoinstrumentasjon)

### DIFF
--- a/deploy/nais.yml
+++ b/deploy/nais.yml
@@ -11,9 +11,9 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 512Mi
-    limits:
       memory: 1024Mi
+    limits:
+      memory: 2048Mi
   replicas:
     max: 2
     min: 2


### PR DESCRIPTION
Når vi skrudde på autoinstrumentasjon så gikk minnebruken fra rundt 300 MB til 900 MB.