### PR TITLE
Konfigurer distroless image med Oslo-tid og mere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM gcr.io/distroless/java21
 COPY build/libs/*.jar ./
+ENV JAVA_OPTS='-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'
+ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
 ENTRYPOINT ["java", "-jar", "/app.jar"]
 EXPOSE 8080


### PR DESCRIPTION
Denne konfigurasjonen er tilstede i flere andre apper, blant annet https://github.com/navikt/helsearbeidsgiver-inntektsmelding/blob/main/Dockerfile.