### PR TITLE
Legg til databasefelt for eksponert forespoersel-ID

### DIFF
--- a/src/main/resources/db/migration/V21__add_column_eksponert_fid.sql
+++ b/src/main/resources/db/migration/V21__add_column_eksponert_fid.sql
@@ -1,5 +1,5 @@
 ALTER TABLE forespoersel
-    ADD COLUMN eksponert_forespoersel_id UUID REFERENCES forespoersel (forespoersel_id),
+    ADD COLUMN eksponert_forespoersel_id UUID REFERENCES forespoersel (forespoersel_id) ON DELETE RESTRICT,
     ALTER COLUMN type TYPE TEXT,
     ALTER COLUMN status TYPE TEXT,
     ALTER COLUMN fnr TYPE TEXT,

--- a/src/main/resources/db/migration/V21__add_column_eksponert_fid.sql
+++ b/src/main/resources/db/migration/V21__add_column_eksponert_fid.sql
@@ -2,5 +2,5 @@ ALTER TABLE forespoersel
     ADD COLUMN eksponert_forespoersel_id UUID REFERENCES forespoersel (forespoersel_id) ON DELETE RESTRICT,
     ALTER COLUMN type TYPE TEXT,
     ALTER COLUMN status TYPE TEXT,
-    ALTER COLUMN fnr TYPE TEXT,
-    ALTER COLUMN orgnr TYPE TEXT;
+    ALTER COLUMN fnr TYPE VARCHAR(11),
+    ALTER COLUMN orgnr TYPE VARCHAR(9);

--- a/src/main/resources/db/migration/V21__add_column_eksponert_fid.sql
+++ b/src/main/resources/db/migration/V21__add_column_eksponert_fid.sql
@@ -1,0 +1,6 @@
+ALTER TABLE forespoersel
+    ADD COLUMN eksponert_forespoersel_id UUID REFERENCES forespoersel (forespoersel_id),
+    ALTER COLUMN type TYPE TEXT,
+    ALTER COLUMN status TYPE TEXT,
+    ALTER COLUMN fnr TYPE TEXT,
+    ALTER COLUMN orgnr TYPE TEXT;


### PR DESCRIPTION
Eksponert forspørsel-ID kan i dag bestemmes om man ser på alle forespørslene til en vedtaksperiode. Det gjøres i dag ved behov, men vi har tidvis opplevd feil i denne oppførselen. Ved å legge verdien inn i databasen blir den mer synlig, og forhåpentligvis blir logikken bak (som er uendret) mer lesbar. Dersom det oppstår feil vil man også kunne se det i databasen.

Tanken er å innføre verdien til databasen gradvis, så feltet starter som nullable, men det er ment til å bli påkrevd på sikt. Vi kan gjøre noe enkel migrering av radene, men jeg tror ikke det er verdt å migrere alt over til å bruke den nye kolonnen. Et eksempel på en enkel migrering er å fylle kolonnen for alle vedtaksperioder som kun har én forespørsel. Da er den eksponerte forespørsel-ID-en den samme som forespørsel-ID-en.

Sniker med noen typeendringer fra VARCHAR til TEXT, siden vi ikke bryr oss om faste lengder. Det gir ingen funksjonelle endringer.