### PR TITLE
Lagre eksponert forespoersel-ID

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiver.kt
@@ -2,7 +2,6 @@ package no.nav.helsearbeidsgiver.bro.sykepenger
 
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreForespoerselRiver.kt
@@ -86,9 +86,16 @@ sealed class LagreForespoerselRiver(
 
         val skalHaPaaminnelse = nyForespoersel.type == Type.KOMPLETT
 
-        if (aktivForespoersel == null || !nyForespoersel.erDuplikatAv(aktivForespoersel)) {
+        val eksponertForespoerselId =
+            when {
+                aktivForespoersel == null -> nyForespoersel.forespoerselId
+                !nyForespoersel.erDuplikatAv(aktivForespoersel) -> aktivForespoersel.forespoerselId
+                else -> null
+            }
+
+        if (eksponertForespoerselId != null) {
             forespoerselDao
-                .lagre(nyForespoersel)
+                .lagre(nyForespoersel, eksponertForespoerselId)
                 .let { id ->
                     "Forespørsel lagret med id=$id.".also {
                         loggernaut.aapen.info(it)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
@@ -2,7 +2,6 @@ package no.nav.helsearbeidsgiver.bro.sykepenger
 
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.bestemmendeFravaersdagerSerializer

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSpleisRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSpleisRiver.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.JsonMessage
 import com.github.navikt.tbd_libs.rapids_and_rivers.River
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.InntektsmeldingHaandtertDto

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
@@ -27,7 +27,10 @@ class ForespoerselDao(
     private val logger = logger()
     private val sikkerLogger = sikkerLogger()
 
-    fun lagre(forespoersel: ForespoerselDto): Long =
+    fun lagre(
+        forespoersel: ForespoerselDto,
+        eksponertForespoerselId: UUID,
+    ): Long =
         transaction(db) {
             oppdaterStatuser(
                 vedtaksperiodeId = forespoersel.vedtaksperiodeId,
@@ -39,6 +42,7 @@ class ForespoerselDao(
             ForespoerselTable
                 .insert {
                     it[forespoerselId] = forespoersel.forespoerselId
+                    it[this.eksponertForespoerselId] = eksponertForespoerselId
                     it[type] = forespoersel.type.name
                     it[status] = forespoersel.status.name
                     it[orgnr] = forespoersel.orgnr.verdi

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/Tables.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/Tables.kt
@@ -17,12 +17,11 @@ object ForespoerselTable : Table("forespoersel") {
             idSeqName = "forespoersel_id_seq",
         )
     val forespoerselId = uuid("forespoersel_id")
-
-    // Denne er varchar av udefinert lengde i databasen
+    val eksponertForespoerselId = uuid("eksponert_forespoersel_id").nullable()
     val type = text("type")
-    val status = varchar("status", 50)
-    val orgnr = varchar("orgnr", 50)
-    val fnr = varchar("fnr", 50)
+    val status = text("status")
+    val orgnr = varchar("orgnr", 9)
+    val fnr = varchar("fnr", 11)
     val vedtaksperiodeId = uuid("vedtaksperiode_id")
     val egenmeldingsperioder = jsonb("egenmeldingsperioder", jsonConfig, Periode.serializer().list())
     val sykmeldingsperioder = jsonb("sykmeldingsperioder", jsonConfig, Periode.serializer().list())
@@ -31,20 +30,12 @@ object ForespoerselTable : Table("forespoersel") {
     val opprettet = datetime("opprettet")
     val oppdatert = datetime("oppdatert")
     val kastetTilInfotrygd = datetime("kastet_til_infotrygd").nullable()
-
-    override val primaryKey = PrimaryKey(id)
 }
 
 object BesvarelseTable : Table("besvarelse_metadata") {
-    private val id =
-        integer("id").autoIncrement(
-            idSeqName = "besvarelse_metadata_id_seq",
-        )
     val fkForespoerselId = long("fk_forespoersel_id") references ForespoerselTable.id
     val besvart = datetime("forespoersel_besvart")
     val inntektsmeldingId = uuid("inntektsmelding_id").nullable()
-
-    override val primaryKey = PrimaryKey(id)
 }
 
 val bestemmendeFravaersdagerSerializer = MapSerializer(Orgnr.serializer(), LocalDateSerializer)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiverTest.kt
@@ -28,6 +28,7 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.util.UUID
 
 class LagreBegrensetForespoerselRiverTest :
     FunSpec({
@@ -86,6 +87,7 @@ class LagreBegrensetForespoerselRiverTest :
                     withArg {
                         it.shouldBeEqualToIgnoringFields(forespoersel, forespoersel::oppdatert, forespoersel::opprettet)
                     },
+                    forespoersel.forespoerselId,
                 )
 
                 mockPriProducer.send(
@@ -98,11 +100,13 @@ class LagreBegrensetForespoerselRiverTest :
 
         test("Oppdatert forespørsel (ubesvart) blir lagret uten å sende notifikasjon") {
             val forespoersel = mockBegrensetForespoerselDto()
+            val eksponertForespoerselId = UUID.randomUUID()
 
             every {
                 mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId)
             } returns
                 forespoersel.copy(
+                    forespoerselId = eksponertForespoerselId,
                     egenmeldingsperioder =
                         listOf(
                             Periode(13.mars(1812), 14.mars(1812)),
@@ -122,6 +126,7 @@ class LagreBegrensetForespoerselRiverTest :
                     withArg {
                         it.shouldBeEqualToIgnoringFields(forespoersel, forespoersel::oppdatert, forespoersel::opprettet)
                     },
+                    eksponertForespoerselId,
                 )
             }
 
@@ -148,7 +153,7 @@ class LagreBegrensetForespoerselRiverTest :
             }
 
             verify(exactly = 0) {
-                mockForespoerselDao.lagre(any())
+                mockForespoerselDao.lagre(any(), any())
 
                 mockPriProducer.send(any())
             }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiverTest.kt
@@ -27,6 +27,7 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.util.UUID
 
 class LagreKomplettForespoerselRiverTest :
     FunSpec({
@@ -84,6 +85,7 @@ class LagreKomplettForespoerselRiverTest :
                     withArg {
                         it.shouldBeEqualToIgnoringFields(forespoersel, forespoersel::oppdatert, forespoersel::opprettet)
                     },
+                    forespoersel.forespoerselId,
                 )
 
                 mockPriProducer.send(
@@ -96,11 +98,13 @@ class LagreKomplettForespoerselRiverTest :
 
         test("Oppdatert forespørsel (ubesvart) blir lagret uten notifikasjon") {
             val forespoersel = mockForespoerselDto()
+            val eksponertForespoerselId = UUID.randomUUID()
 
             every {
                 mockForespoerselDao.hentAktivForespoerselForVedtaksperiodeId(forespoersel.vedtaksperiodeId)
             } returns
                 forespoersel.copy(
+                    forespoerselId = eksponertForespoerselId,
                     egenmeldingsperioder =
                         listOf(
                             Periode(13.mars(1812), 14.mars(1812)),
@@ -120,6 +124,7 @@ class LagreKomplettForespoerselRiverTest :
                     withArg {
                         it.shouldBeEqualToIgnoringFields(forespoersel, forespoersel::oppdatert, forespoersel::opprettet)
                     },
+                    eksponertForespoerselId,
                 )
             }
 
@@ -146,7 +151,7 @@ class LagreKomplettForespoerselRiverTest :
             }
 
             verify(exactly = 0) {
-                mockForespoerselDao.lagre(any())
+                mockForespoerselDao.lagre(any(), any())
 
                 mockPriProducer.send(any())
             }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSimbaRiverTest.kt
@@ -7,7 +7,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
-import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockForespoerselDto

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSpleisRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerBesvartFraSpleisRiverTest.kt
@@ -7,7 +7,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
-import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.InntektsmeldingHaandtertDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
@@ -16,10 +15,10 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.spleis.Spleis
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.MockUuid
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockInntektsmeldingHaandtertDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.sendJson
-import no.nav.helsearbeidsgiver.bro.sykepenger.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.util.UUID
 
 class MarkerBesvartFraSpleisRiverTest :
     FunSpec({
@@ -86,7 +85,7 @@ class MarkerBesvartFraSpleisRiverTest :
 
         test("Sier ifra til Simba om besvart forespørsel dersom minst én forespørsel oppdateres") {
             val inntektsmeldingHaandtert = mockInntektsmeldingHaandtertDto(dokumentId = null)
-            val expectedForespoerselId = randomUuid()
+            val expectedForespoerselId = UUID.randomUUID()
 
             every { mockForespoerselDao.oppdaterForespoerslerSomBesvartFraSpleis(any(), any(), any()) } returns 1
 
@@ -121,7 +120,7 @@ class MarkerBesvartFraSpleisRiverTest :
 
         test("Sender forespørselId-en Simba forventer når forespørsel markeres som besvart") {
             val inntektsmeldingHaandtert = mockInntektsmeldingHaandtertDto(dokumentId = null)
-            val expectedForespoerselId = randomUuid()
+            val expectedForespoerselId = UUID.randomUUID()
 
             every {
                 mockForespoerselDao.oppdaterForespoerslerSomBesvartFraSpleis(
@@ -150,7 +149,7 @@ class MarkerBesvartFraSpleisRiverTest :
 
         test("Videresender inntektsmeldingId når forespørsel markeres som besvart") {
             val inntektsmeldingHaandtert = mockInntektsmeldingHaandtertDto(dokumentId = MockUuid.inntektsmeldingId)
-            val expectedForespoerselId = randomUuid()
+            val expectedForespoerselId = UUID.randomUUID()
 
             every {
                 mockForespoerselDao.oppdaterForespoerslerSomBesvartFraSpleis(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvarTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselSvarTest.kt
@@ -5,7 +5,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockForespoerselSvarSuksess
-import no.nav.helsearbeidsgiver.bro.sykepenger.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -13,6 +12,7 @@ import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.time.LocalDate
+import java.util.UUID
 
 class ForespoerselSvarTest :
     FunSpec({
@@ -56,7 +56,7 @@ class ForespoerselSvarTest :
 
 private fun mockForespoerselSvarUtenSuksessEllerFeil(): ForespoerselSvar =
     ForespoerselSvar(
-        forespoerselId = randomUuid(),
+        forespoerselId = UUID.randomUUID(),
         boomerang =
             mapOf(
                 "boom" to "shakalaka".toJson(),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/kafkatopic/pri/PriProducerTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/kafkatopic/pri/PriProducerTest.kt
@@ -9,7 +9,6 @@ import io.mockk.mockk
 import io.mockk.verifySequence
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockForespoerselMottatt
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.toKeyMap
-import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
@@ -23,7 +23,6 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisRefusjon
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
-import no.nav.helsearbeidsgiver.bro.sykepenger.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.august
@@ -39,7 +38,6 @@ import java.util.UUID
 
 object MockUuid {
     val vedtaksperiodeId: UUID = "01234567-abcd-0123-abcd-012345678901".let(UUID::fromString)
-    val forespoerselId: UUID = "98765654-abcd-0123-abcd-012345678901".let(UUID::fromString)
     val inntektsmeldingId: UUID = "22efb342-3e72-4880-a449-eb1efcf0f18b".let(UUID::fromString)
 }
 
@@ -47,7 +45,7 @@ fun mockForespoerselDto(): ForespoerselDto {
     val orgnr = Orgnr.genererGyldig()
 
     return ForespoerselDto(
-        forespoerselId = randomUuid(),
+        forespoerselId = UUID.randomUUID(),
         type = Type.KOMPLETT,
         status = Status.AKTIV,
         orgnr = orgnr,


### PR DESCRIPTION
Eksponert forspørsel-ID kan i dag bestemmes om man ser på alle forespørslene til en vedtaksperiode. Det gjøres i dag ved behov, men vi har tidvis opplevd feil i denne oppførselen. Ved å legge verdien inn i databasen blir den mer synlig, og forhåpentligvis blir logikken bak (som er uendret) mer lesbar. Dersom det oppstår feil vil man også kunne se det i databasen.

Tanken er å innføre verdien til databasen gradvis, så feltet starter som nullable, men det er ment til å bli påkrevd på sikt. Vi kan gjøre noe enkel migrering av radene, men jeg tror ikke det er verdt å migrere alt over til å bruke den nye kolonnen. Et eksempel på en enkel migrering er å fylle kolonnen for alle vedtaksperioder som kun har én forespørsel. Da er den eksponerte forespørsel-ID-en den samme som forespørsel-ID-en.
