### PR TITLE
Legg til index for eksponert forespørsel-ID

### DIFF
--- a/src/main/resources/db/migration/V22__create_index_eksponert_fid.sql
+++ b/src/main/resources/db/migration/V22__create_index_eksponert_fid.sql
@@ -1,0 +1,3 @@
+DROP INDEX idx_forespoersel_id;
+
+CREATE INDEX idx_eksponert_forespoersel_id ON forespoersel (eksponert_forespoersel_id);


### PR DESCRIPTION
Jeg prøvde å slette rader fra forespørseldatabasen, men det tok utrolig lang tid. Mistenker at `eksponert_forespoersel_id` har skylden, ettersom den er en foreign key mot `forespoersel_id` med on cascade, men ingen indeks.

Sletter `idx_forespoersel_id` i samme slengen, siden det er en duplisert index på `forespoersel_id`. Den kolonnen er automatisk indeksert siden den er unik og "not null".