### PR TITLE
Midlertidig: Endre deploy-strategi til Recreate pga. db-migrering

### DIFF
--- a/deploy/nais.yml
+++ b/deploy/nais.yml
@@ -8,6 +8,9 @@ metadata:
     app: helsearbeidsgiver-bro-sykepenger
 spec:
   image: {{ image }}
+  # Midlertidig, for å hindre at gamle poder spør databasen mens nye poder utfører migrering
+  strategy:
+    type: Recreate
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
For de som ønsker å lese mer om hvorfor:
- https://github.com/navikt/rapids-and-rivers?tab=readme-ov-file#appen-min-har-database
- https://doc.nav.cloud.nais.io/workloads/application/reference/application-spec/#strategytype
- https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy