### PR TITLE
Ikke send melding til Simba om kastet til Infotrygd for besvarte forespørsler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 *.tar.gz
 *.rar
 
+# Kotlin
+.kotlin
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
@@ -279,7 +279,7 @@ private fun List<Pair<UUID, ForespoerselDto>>.finnNyesteForespoerselPerVedtakspe
                         forespoerselId = eksponertForespoerselId,
                     )
                 }
-        }
+        }.sortedBy { it.opprettet }
 
 fun tilForespoerselTilLpsapi(row: ResultRow): ForespoerselDtoMedEksponertFsp =
     ForespoerselDtoMedEksponertFsp(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerKastetTilInfotrygdRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerKastetTilInfotrygdRiverTest.kt
@@ -2,16 +2,17 @@ package no.nav.helsearbeidsgiver.bro.sykepenger
 
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.PriProducer
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.spleis.Spleis
-import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.MockUuid.vedtaksperiodeId
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockForespoerselDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.sendJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -22,8 +23,6 @@ class MarkerKastetTilInfotrygdRiverTest :
         val testRapid = TestRapid()
         val mockForespoerselDao = mockk<ForespoerselDao>(relaxed = true)
         val mockPriProducer = mockk<PriProducer>(relaxed = true)
-
-        val mockForespoersel = mockForespoerselDto()
 
         MarkerKastetTilInfotrygdRiver(
             rapid = testRapid,
@@ -38,31 +37,22 @@ class MarkerKastetTilInfotrygdRiverTest :
             )
         }
 
-        beforeEach {
+        beforeTest {
             clearAllMocks()
         }
 
-        test("Innkommende event markerer vedtaksperiode kastet til infotrygd") {
+        test("Oppdaterer database og sender melding til Simba ved aktiv forespørsel") {
+            val mockForespoersel = mockForespoerselDto().copy(status = Status.AKTIV)
+
             every {
-                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(vedtaksperiodeId))
+                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(mockForespoersel.vedtaksperiodeId))
             } returns listOf(mockForespoersel)
 
-            mockMarkerKastetTilInfotrygdMelding(vedtaksperiodeId)
+            mockMarkerKastetTilInfotrygdMelding(mockForespoersel.vedtaksperiodeId)
 
             verifySequence {
-                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(vedtaksperiodeId))
-                mockForespoerselDao.markerKastetTilInfotrygd(vedtaksperiodeId)
-            }
-        }
-
-        test("Sier ifra til Simba om at påminnelse for forespørsel skal avbestilles") {
-            every {
-                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(vedtaksperiodeId))
-            } returns listOf(mockForespoersel)
-
-            mockMarkerKastetTilInfotrygdMelding(vedtaksperiodeId)
-
-            verifySequence {
+                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(mockForespoersel.vedtaksperiodeId))
+                mockForespoerselDao.markerKastetTilInfotrygd(mockForespoersel.vedtaksperiodeId)
                 mockPriProducer.send(
                     Pri.Key.NOTIS to Pri.NotisType.FORESPOERSEL_KASTET_TIL_INFOTRYGD.toJson(Pri.NotisType.serializer()),
                     Pri.Key.FORESPOERSEL_ID to mockForespoersel.forespoerselId.toJson(),
@@ -70,31 +60,44 @@ class MarkerKastetTilInfotrygdRiverTest :
             }
         }
 
-        test(
-            "Sier ikke ifra til Simba om at påminnelse for forespørsel skal avbestilles dersom vi ikke finner forespørsler for vedtaksperiode-id",
-        ) {
-            mockMarkerKastetTilInfotrygdMelding(vedtaksperiodeId)
+        context("Oppdaterer database, men sender _ikke_ melding til Simba ved besvart forespørsel") {
+            withData(
+                Status.BESVART_SIMBA,
+                Status.BESVART_SPLEIS,
+            ) { besvartStatus ->
+                val mockForespoersel = mockForespoerselDto().copy(status = besvartStatus)
 
-            every {
-                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(vedtaksperiodeId))
-            } returns emptyList()
+                every {
+                    mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(mockForespoersel.vedtaksperiodeId))
+                } returns listOf(mockForespoersel)
 
-            verify(exactly = 0) {
-                mockPriProducer.send(any(), any())
+                mockMarkerKastetTilInfotrygdMelding(mockForespoersel.vedtaksperiodeId)
+
+                verifySequence {
+                    mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(mockForespoersel.vedtaksperiodeId))
+                    mockForespoerselDao.markerKastetTilInfotrygd(mockForespoersel.vedtaksperiodeId)
+                }
+                verify(exactly = 0) {
+                    mockPriProducer.send(*anyVararg())
+                }
             }
         }
 
-        test(
-            "Markerer ikke vedtaksperiode kastet til infotrygd dersom vi ikke finner forespørsler for vedtaksperiode-id",
-        ) {
-            mockMarkerKastetTilInfotrygdMelding(vedtaksperiodeId)
+        test("Hverken oppdaterer database eller sender melding til Simba dersom vi ikke finner forespørsler for vedtaksperiode-ID") {
+            val vedtaksperiodeId = UUID.randomUUID()
 
             every {
                 mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(vedtaksperiodeId))
             } returns emptyList()
 
+            mockMarkerKastetTilInfotrygdMelding(vedtaksperiodeId)
+
+            verifySequence {
+                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(vedtaksperiodeId))
+            }
             verify(exactly = 0) {
                 mockForespoerselDao.markerKastetTilInfotrygd(any())
+                mockPriProducer.send(any(), any())
             }
         }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDaoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDaoTest.kt
@@ -1237,8 +1237,9 @@ class ForespoerselDaoTest :
 
                 actualForespoersler.size shouldBeExactly 2
 
-                actualForespoersler[0] shouldBe forespoersel3Gruppe1
-                actualForespoersler[1] shouldBe forespoerselGruppe2
+                // Rekkefølgen kommer av opprettelsestidspunktet
+                actualForespoersler[0] shouldBe forespoerselGruppe2
+                actualForespoersler[1] shouldBe forespoersel3Gruppe1
             }
         }
 


### PR DESCRIPTION
I dag prøver Simba å fjerne påminnelser på lukkede Fager-saker når appen mottar "kastet til Infotrygd"-melding på besvarte forespørsler. Dette feiler med en warning og lager en del støy i loggene.