### PR TITLE
Ikke send melding til Simba om kastet til Infotrygd for begrensede forespørsler

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerKastetTilInfotrygdRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerKastetTilInfotrygdRiver.kt
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.MeterRegistry
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.PriProducer
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.spleis.Spleis
@@ -74,7 +75,7 @@ class MarkerKastetTilInfotrygdRiver(
                 .hentForespoerslerEksponertTilSimba(setOf(vedtaksperiodeId))
                 .firstOrNull()
 
-        if (forespoersel != null) {
+        if (forespoersel != null && forespoersel.type == Type.KOMPLETT) {
             forespoerselDao.markerKastetTilInfotrygd(vedtaksperiodeId)
 
             if (forespoersel.status == Status.AKTIV) {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerKastetTilInfotrygdRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MarkerKastetTilInfotrygdRiverTest.kt
@@ -10,6 +10,7 @@ import io.mockk.verify
 import io.mockk.verifySequence
 import no.nav.helsearbeidsgiver.bro.sykepenger.db.ForespoerselDao
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.Pri
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.pri.PriProducer
 import no.nav.helsearbeidsgiver.bro.sykepenger.kafkatopic.spleis.Spleis
@@ -94,6 +95,24 @@ class MarkerKastetTilInfotrygdRiverTest :
 
             verifySequence {
                 mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(vedtaksperiodeId))
+            }
+            verify(exactly = 0) {
+                mockForespoerselDao.markerKastetTilInfotrygd(any())
+                mockPriProducer.send(any(), any())
+            }
+        }
+
+        test("Hverken oppdaterer database eller sender melding til Simba dersom vi finner begrenset forespørsel") {
+            val mockForespoersel = mockForespoerselDto().copy(type = Type.BEGRENSET)
+
+            every {
+                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(mockForespoersel.vedtaksperiodeId))
+            } returns listOf(mockForespoersel)
+
+            mockMarkerKastetTilInfotrygdMelding(mockForespoersel.vedtaksperiodeId)
+
+            verifySequence {
+                mockForespoerselDao.hentForespoerslerEksponertTilSimba(setOf(mockForespoersel.vedtaksperiodeId))
             }
             verify(exactly = 0) {
                 mockForespoerselDao.markerKastetTilInfotrygd(any())


### PR DESCRIPTION
I dag prøver Simba å fjerne ikke-eksisterende påminnelser på Fager-saker når appen mottar "kastet til Infotrygd"-melding på begrensede forespørsler. Dette feiler med en warning og lager en del støy i loggene.

Denne PR-en følger https://github.com/navikt/helsearbeidsgiver-bro-sykepenger/pull/112, som fikk bukt med deler av problemet.