### PR TITLE
Slå forespurt data sammen med historiske verdier

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiver.kt
@@ -20,6 +20,7 @@ import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.util.UUID
@@ -66,6 +67,6 @@ class LagreBegrensetForespoerselRiver(
             egenmeldingsperioder = emptyList(),
             sykmeldingsperioder = Spleis.Key.SYKMELDINGSPERIODER.les(Periode.serializer().list(), melding),
             bestemmendeFravaersdager = emptyMap(),
-            forespurtData = Spleis.Key.FORESPURT_DATA.les(SpleisForespurtDataDto.serializer().list(), melding),
+            forespurtData = Spleis.Key.FORESPURT_DATA.les(SpleisForespurtDataDto.serializer().set(), melding),
         )
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreForespoerselRiver.kt
@@ -120,7 +120,10 @@ sealed class LagreForespoerselRiver(
     ): UUID? =
         when {
             aktivForespoersel == null -> nyForespoersel.forespoerselId
+
+            // Siden vi legger til historisk forespurt data når en forespørsel leses fra databasen, så kan innkommende forespørsel anses som duplikat selv om forespurt data er ulik databaseraden til den aktive forespørselen
             !nyForespoersel.erDuplikatAv(aktivForespoersel) -> aktivForespoersel.forespoerselId
+
             else -> null
         }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiver.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
@@ -82,7 +83,7 @@ class LagreKomplettForespoerselRiver(
                 egenmeldingsperioder = Spleis.Key.EGENMELDINGSPERIODER.les(Periode.serializer().list(), melding),
                 sykmeldingsperioder = Spleis.Key.SYKMELDINGSPERIODER.les(Periode.serializer().list(), melding),
                 bestemmendeFravaersdager = bestemmendeFravaersdager,
-                forespurtData = Spleis.Key.FORESPURT_DATA.les(SpleisForespurtDataDto.serializer().list(), melding),
+                forespurtData = Spleis.Key.FORESPURT_DATA.les(SpleisForespurtDataDto.serializer().set(), melding),
             )
 
         val bfUtenEgenmld =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MapForespurtData.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MapForespurtData.kt
@@ -9,7 +9,7 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisInntekt
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisRefusjon
 
-fun List<SpleisForespurtDataDto>.tilForespurtData(): ForespurtData =
+fun Set<SpleisForespurtDataDto>.tilForespurtData(): ForespurtData =
     ForespurtData(
         arbeidsgiverperiode =
             Arbeidsgiverperiode(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDao.kt
@@ -1,6 +1,7 @@
 package no.nav.helsearbeidsgiver.bro.sykepenger.db
 
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.truncMillis
@@ -238,15 +239,32 @@ fun tilForespoerselDto(row: ResultRow): ForespoerselDto =
     )
 
 private fun List<Pair<UUID, ForespoerselDto>>.finnNyesteForespoerselPerVedtaksperiodeId(statuser: Set<Status>): List<ForespoerselDto> =
-    groupBy { it.second.vedtaksperiodeId }
-        .mapNotNull { (_, eksponertIdOgForespoerselListe) ->
-            eksponertIdOgForespoerselListe
-                .sortedByDescending { it.second.opprettet }
-                .firstOrNull { it.second.status in statuser }
-                ?.let { (eksponertForespoerselId, nyesteForespoersel) ->
-                    // Simba kjenner kun til eksponerte forespørsel-ID-er, så vi må bytte for at ID-en skal matche Simbas systemer.
-                    nyesteForespoersel.copy(
-                        forespoerselId = eksponertForespoerselId,
-                    )
-                }
-        }.sortedBy { it.opprettet }
+    map { (eksponertForespoerselId, nyesteForespoersel) ->
+        // Simba kjenner kun til eksponerte forespørsel-ID-er, så vi må bytte for at ID-en skal matche Simbas systemer.
+        nyesteForespoersel.copy(
+            forespoerselId = eksponertForespoerselId,
+        )
+    }.groupBy { it.vedtaksperiodeId }
+        .mapNotNull { (_, forespoersler) ->
+            forespoersler
+                .mergeHistoriskForespurtData()
+                .sortedBy { it.opprettet }
+                .lastOrNull { it.status in statuser }
+        }
+
+/**
+ * Slår sammen historisk forespurt data, slik at en forespørsel vil be om alt som er bedt om i tidligere forespørsler.
+ * Tar _ikke_ hensyn til om forespørsler tilhører ulike vedtaksperioder.
+ */
+private fun List<ForespoerselDto>.mergeHistoriskForespurtData(): List<ForespoerselDto> =
+    sortedBy { it.opprettet }
+        .fold(
+            emptySet<SpleisForespurtDataDto>() to emptyList<ForespoerselDto>(),
+        ) { (mergedForespurtData, mergedForespoersler), forespoersel ->
+            if (forespoersel.status == Status.FORKASTET || forespoersel.forespurtData == mergedForespurtData) {
+                mergedForespurtData to mergedForespoersler.plus(forespoersel)
+            } else {
+                val nyMerged = mergedForespurtData.plus(forespoersel.forespurtData)
+                nyMerged to mergedForespoersler.plus(forespoersel.copy(forespurtData = nyMerged))
+            }
+        }.second

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/Tables.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/Tables.kt
@@ -6,6 +6,7 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.java.javaUUID
@@ -27,7 +28,7 @@ object ForespoerselTable : Table("forespoersel") {
     val egenmeldingsperioder = jsonb("egenmeldingsperioder", jsonConfig, Periode.serializer().list())
     val sykmeldingsperioder = jsonb("sykmeldingsperioder", jsonConfig, Periode.serializer().list())
     val bestemmendeFravaersdager = jsonb("bestemmende_fravaersdager", jsonConfig, bestemmendeFravaersdagerSerializer)
-    val forespurtData = jsonb("forespurt_data", jsonConfig, SpleisForespurtDataDto.serializer().list())
+    val forespurtData = jsonb("forespurt_data", jsonConfig, SpleisForespurtDataDto.serializer().set())
     val opprettet = datetime("opprettet")
     val oppdatert = datetime("oppdatert")
     val kastetTilInfotrygd = datetime("kastet_til_infotrygd").nullable()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDto.kt
@@ -24,7 +24,7 @@ data class ForespoerselDto(
     val egenmeldingsperioder: List<Periode>,
     val sykmeldingsperioder: List<Periode>,
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
-    val forespurtData: List<SpleisForespurtDataDto>,
+    val forespurtData: Set<SpleisForespurtDataDto>,
     val opprettet: LocalDateTime = LocalDateTime.now().truncMillis(),
     val oppdatert: LocalDateTime = LocalDateTime.now().truncMillis(),
     val kastetTilInfotrygd: LocalDateTime? = null,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreBegrensetForespoerselRiverTest.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.tilMeldingForespoerselM
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.tilMeldingForespoerselOppdatert
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
@@ -47,7 +48,7 @@ class LagreBegrensetForespoerselRiverTest :
                 Spleis.Key.FØDSELSNUMMER to forespoersel.fnr.toJson(),
                 Spleis.Key.VEDTAKSPERIODE_ID to forespoersel.vedtaksperiodeId.toJson(),
                 Spleis.Key.SYKMELDINGSPERIODER to forespoersel.sykmeldingsperioder.toJson(Periode.serializer().list()),
-                Spleis.Key.FORESPURT_DATA to forespoersel.forespurtData.toJson(SpleisForespurtDataDto.serializer().list()),
+                Spleis.Key.FORESPURT_DATA to forespoersel.forespurtData.toJson(SpleisForespurtDataDto.serializer().set()),
             )
         }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/LagreKomplettForespoerselRiverTest.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.tilMeldingForespoerselM
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.tilMeldingForespoerselOppdatert
 import no.nav.helsearbeidsgiver.bro.sykepenger.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
@@ -49,7 +50,7 @@ class LagreKomplettForespoerselRiverTest :
                 Spleis.Key.EGENMELDINGSPERIODER to forespoersel.egenmeldingsperioder.toJson(Periode.serializer().list()),
                 Spleis.Key.SYKMELDINGSPERIODER to forespoersel.sykmeldingsperioder.toJson(Periode.serializer().list()),
                 Spleis.Key.BESTEMMENDE_FRAVÆRSDAGER to forespoersel.bestemmendeFravaersdager.toJson(bestemmendeFravaersdagerSerializer),
-                Spleis.Key.FORESPURT_DATA to forespoersel.forespurtData.toJson(SpleisForespurtDataDto.serializer().list()),
+                Spleis.Key.FORESPURT_DATA to forespoersel.forespurtData.toJson(SpleisForespurtDataDto.serializer().set()),
             )
         }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MapForespurtDataKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/MapForespurtDataKtTest.kt
@@ -28,7 +28,7 @@ class MapForespurtDataKtTest :
                     refusjon = Refusjon(paakrevd = true),
                 )
 
-            val mappedForespurtData = listOf(SpleisArbeidsgiverperiode, SpleisInntekt, SpleisRefusjon).tilForespurtData()
+            val mappedForespurtData = setOf(SpleisArbeidsgiverperiode, SpleisInntekt, SpleisRefusjon).tilForespurtData()
 
             mappedForespurtData shouldBe expectedForespurtData
         }
@@ -41,7 +41,7 @@ class MapForespurtDataKtTest :
                     refusjon = Refusjon(paakrevd = false),
                 )
 
-            val mappedForespurtData = emptyList<SpleisForespurtDataDto>().tilForespurtData()
+            val mappedForespurtData = emptySet<SpleisForespurtDataDto>().tilForespurtData()
 
             mappedForespurtData shouldBe expectedForespurtData
         }
@@ -54,7 +54,7 @@ class MapForespurtDataKtTest :
                     refusjon = Refusjon(paakrevd = true),
                 )
 
-            val mappedForespurtData = listOf(SpleisArbeidsgiverperiode, SpleisFastsattInntekt, SpleisRefusjon).tilForespurtData()
+            val mappedForespurtData = setOf(SpleisArbeidsgiverperiode, SpleisFastsattInntekt, SpleisRefusjon).tilForespurtData()
 
             mappedForespurtData shouldBe expectedForespurtData
         }
@@ -68,7 +68,7 @@ class MapForespurtDataKtTest :
                         refusjon = Refusjon(paakrevd = false),
                     )
 
-                val spleisForespurtData = listOf(SpleisArbeidsgiverperiode)
+                val spleisForespurtData = setOf(SpleisArbeidsgiverperiode)
 
                 val mappedForespurtData = spleisForespurtData.tilForespurtData()
 
@@ -83,7 +83,7 @@ class MapForespurtDataKtTest :
                         refusjon = Refusjon(paakrevd = true),
                     )
 
-                val mappedForespurtData = listOf(SpleisInntekt, SpleisRefusjon).tilForespurtData()
+                val mappedForespurtData = setOf(SpleisInntekt, SpleisRefusjon).tilForespurtData()
 
                 mappedForespurtData shouldBe expectedForespurtData
             }
@@ -98,7 +98,7 @@ class MapForespurtDataKtTest :
                         refusjon = Refusjon(paakrevd = false),
                     )
 
-                val spleisForespurtData = listOf(SpleisInntekt)
+                val spleisForespurtData = setOf(SpleisInntekt)
 
                 val mappedForespurtData = spleisForespurtData.tilForespurtData()
 
@@ -113,7 +113,7 @@ class MapForespurtDataKtTest :
                         refusjon = Refusjon(paakrevd = true),
                     )
 
-                val mappedForespurtData = listOf(SpleisArbeidsgiverperiode, SpleisRefusjon).tilForespurtData()
+                val mappedForespurtData = setOf(SpleisArbeidsgiverperiode, SpleisRefusjon).tilForespurtData()
 
                 mappedForespurtData shouldBe expectedForespurtData
             }
@@ -128,7 +128,7 @@ class MapForespurtDataKtTest :
                         refusjon = Refusjon(paakrevd = true),
                     )
 
-                val mappedForespurtData = listOf(SpleisRefusjon).tilForespurtData()
+                val mappedForespurtData = setOf(SpleisRefusjon).tilForespurtData()
 
                 mappedForespurtData shouldBe expectedForespurtData
             }
@@ -141,7 +141,7 @@ class MapForespurtDataKtTest :
                         refusjon = Refusjon(paakrevd = false),
                     )
 
-                val mappedForespurtData = listOf(SpleisArbeidsgiverperiode, SpleisInntekt).tilForespurtData()
+                val mappedForespurtData = setOf(SpleisArbeidsgiverperiode, SpleisInntekt).tilForespurtData()
 
                 mappedForespurtData shouldBe expectedForespurtData
             }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDaoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/db/ForespoerselDaoTest.kt
@@ -14,6 +14,10 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.ForespoerselDto
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Periode
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisArbeidsgiverperiode
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisForespurtDataDto
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisInntekt
+import no.nav.helsearbeidsgiver.bro.sykepenger.domene.SpleisRefusjon
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Status
 import no.nav.helsearbeidsgiver.bro.sykepenger.domene.Type.BEGRENSET
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.MockUuid
@@ -254,6 +258,98 @@ class ForespoerselDaoTest :
                             .shouldNotBeNull()
 
                     actualForespoersel shouldBe aktivForespoersel.copy(forespoerselId = eksponertForespoersel.forespoerselId)
+                }
+            }
+
+            context("Henter aktiv forespørsel med historisk forespurt data") {
+                withData(
+                    mapOf(
+                        "Ignorerer forkastede" to
+                            Pair(
+                                listOf(
+                                    Status.FORKASTET to setOf(SpleisRefusjon),
+                                    Status.FORKASTET to setOf(SpleisArbeidsgiverperiode),
+                                    Status.AKTIV to setOf(SpleisInntekt),
+                                ),
+                                setOf(SpleisInntekt),
+                            ),
+                        "Hensyntar besvart fra Simba" to
+                            Pair(
+                                listOf(
+                                    Status.FORKASTET to setOf(SpleisArbeidsgiverperiode),
+                                    Status.BESVART_SIMBA to setOf(SpleisInntekt),
+                                    Status.AKTIV to setOf(SpleisRefusjon),
+                                ),
+                                setOf(SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Hensyntar besvart fra Spleis" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SPLEIS to setOf(SpleisInntekt),
+                                    Status.FORKASTET to setOf(SpleisArbeidsgiverperiode),
+                                    Status.AKTIV to setOf(SpleisRefusjon),
+                                ),
+                                setOf(SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Hensyntar flere besvarte" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SIMBA to setOf(SpleisArbeidsgiverperiode, SpleisInntekt),
+                                    Status.BESVART_SPLEIS to setOf(SpleisRefusjon),
+                                    Status.AKTIV to setOf(SpleisArbeidsgiverperiode),
+                                ),
+                                setOf(SpleisArbeidsgiverperiode, SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Hensyntar all forespurt data" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SPLEIS to setOf(SpleisInntekt, SpleisRefusjon),
+                                    Status.FORKASTET to setOf(SpleisInntekt),
+                                    Status.AKTIV to setOf(SpleisArbeidsgiverperiode),
+                                ),
+                                setOf(SpleisArbeidsgiverperiode, SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Tåler overlapp" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SPLEIS to setOf(SpleisInntekt, SpleisRefusjon),
+                                    Status.AKTIV to setOf(SpleisArbeidsgiverperiode, SpleisInntekt),
+                                ),
+                                setOf(SpleisArbeidsgiverperiode, SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Ignorerer eksisterende" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SIMBA to setOf(SpleisInntekt),
+                                    Status.AKTIV to setOf(SpleisInntekt, SpleisRefusjon),
+                                ),
+                                setOf(SpleisInntekt, SpleisRefusjon),
+                            ),
+                    ),
+                ) { (statusOgForespurtData, expectedForespurtData) ->
+                    // Skal ikke påvirke innhold i forventet forespurt data pga. ulik vedtaksperiode-ID
+                    mockForespoerselDto()
+                        .copy(
+                            vedtaksperiodeId = UUID.randomUUID(),
+                            forespurtData = setOf(SpleisArbeidsgiverperiode),
+                        ).lagreEksponertNotNull()
+
+                    val expectedForespoersel =
+                        statusOgForespurtData
+                            .tilForespoersler()
+                            .onEach { it.lagreEksponertNotNull() }
+                            .lastOrNull { it.status == Status.AKTIV }
+                            .shouldNotBeNull()
+                            .copy(
+                                forespurtData = expectedForespurtData,
+                            )
+
+                    val actualForespoersel =
+                        forespoerselDao
+                            .hentAktivForespoerselForVedtaksperiodeId(expectedForespoersel.vedtaksperiodeId)
+                            .shouldNotBeNull()
+
+                    actualForespoersel shouldBe expectedForespoersel
                 }
             }
 
@@ -884,24 +980,6 @@ class ForespoerselDaoTest :
                 forespoerslerEksponertTilSimba.shouldContainExactly(a)
             }
 
-            test("tåler ingen forespørsler") {
-                val forespoerslerEksponertTilSimba =
-                    forespoerselDao.hentForespoerslerEksponertTilSimba(setOf(MockUuid.vedtaksperiodeId))
-
-                forespoerslerEksponertTilSimba.shouldBeEmpty()
-            }
-
-            test("tåler ingen ønskede forespørsler") {
-                val idA = mockForespoerselDto().lagreEksponertNotNull()
-
-                db.oppdaterStatus(idA, Status.FORKASTET)
-
-                val forespoerslerEksponertTilSimba =
-                    forespoerselDao.hentForespoerslerEksponertTilSimba(setOf(MockUuid.vedtaksperiodeId))
-
-                forespoerslerEksponertTilSimba.shouldBeEmpty()
-            }
-
             test("tåler mer enn to eksponerte forespørsler (med ujevnt antall forespørsler mellom)") {
                 val eksponertForespoerselIdB = UUID.randomUUID()
 
@@ -1029,6 +1107,135 @@ class ForespoerselDaoTest :
                     a,
                     c.copy(forespoerselId = b.forespoerselId),
                 )
+            }
+
+            context("Henter eksponerte forespørsler med historisk forespurt data") {
+                withData(
+                    mapOf(
+                        "Ignorerer forkastede" to
+                            Pair(
+                                listOf(
+                                    Status.FORKASTET to setOf(SpleisRefusjon),
+                                    Status.FORKASTET to setOf(SpleisArbeidsgiverperiode),
+                                    Status.AKTIV to setOf(SpleisInntekt),
+                                ),
+                                setOf(SpleisInntekt),
+                            ),
+                        "Hensyntar besvart fra Simba" to
+                            Pair(
+                                listOf(
+                                    Status.FORKASTET to setOf(SpleisArbeidsgiverperiode),
+                                    Status.BESVART_SIMBA to setOf(SpleisInntekt),
+                                    Status.AKTIV to setOf(SpleisRefusjon),
+                                ),
+                                setOf(SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Hensyntar besvart fra Spleis" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SPLEIS to setOf(SpleisInntekt),
+                                    Status.FORKASTET to setOf(SpleisArbeidsgiverperiode),
+                                    Status.AKTIV to setOf(SpleisRefusjon),
+                                ),
+                                setOf(SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Hensyntar flere besvarte" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SIMBA to setOf(SpleisArbeidsgiverperiode, SpleisInntekt),
+                                    Status.BESVART_SPLEIS to setOf(SpleisRefusjon),
+                                    Status.AKTIV to setOf(SpleisArbeidsgiverperiode),
+                                ),
+                                setOf(SpleisArbeidsgiverperiode, SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Hensyntar all forespurt data" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SPLEIS to setOf(SpleisInntekt, SpleisRefusjon),
+                                    Status.FORKASTET to setOf(SpleisInntekt),
+                                    Status.AKTIV to setOf(SpleisArbeidsgiverperiode),
+                                ),
+                                setOf(SpleisArbeidsgiverperiode, SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Tåler overlapp" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SPLEIS to setOf(SpleisInntekt, SpleisRefusjon),
+                                    Status.AKTIV to setOf(SpleisArbeidsgiverperiode, SpleisInntekt),
+                                ),
+                                setOf(SpleisArbeidsgiverperiode, SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Ignorerer eksisterende" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SIMBA to setOf(SpleisInntekt),
+                                    Status.AKTIV to setOf(SpleisInntekt, SpleisRefusjon),
+                                ),
+                                setOf(SpleisInntekt, SpleisRefusjon),
+                            ),
+                        "Besvart fra Simba ivaretar historikk" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SIMBA to setOf(SpleisArbeidsgiverperiode),
+                                    Status.FORKASTET to setOf(SpleisInntekt),
+                                    Status.BESVART_SPLEIS to setOf(SpleisRefusjon),
+                                    Status.BESVART_SIMBA to setOf(SpleisArbeidsgiverperiode),
+                                ),
+                                setOf(SpleisArbeidsgiverperiode, SpleisRefusjon),
+                            ),
+                        "Besvart fra Spleis ivaretar historikk" to
+                            Pair(
+                                listOf(
+                                    Status.BESVART_SPLEIS to setOf(SpleisArbeidsgiverperiode),
+                                    Status.FORKASTET to setOf(SpleisInntekt),
+                                    Status.BESVART_SIMBA to setOf(SpleisRefusjon),
+                                    Status.BESVART_SPLEIS to setOf(SpleisArbeidsgiverperiode),
+                                ),
+                                setOf(SpleisArbeidsgiverperiode, SpleisRefusjon),
+                            ),
+                    ),
+                ) { (statusOgForespurtData, expectedForespurtData) ->
+                    // Skal ikke påvirke innhold i forventet forespurt data pga. ulik vedtaksperiode-ID
+                    mockForespoerselDto()
+                        .copy(
+                            vedtaksperiodeId = UUID.randomUUID(),
+                            forespurtData = setOf(SpleisArbeidsgiverperiode),
+                        ).lagreEksponertNotNull()
+
+                    val expectedForespoersel =
+                        statusOgForespurtData
+                            .tilForespoersler()
+                            .onEach { it.lagreEksponertNotNull() }
+                            .lastOrNull { it.status != Status.FORKASTET }
+                            .shouldNotBeNull()
+                            .copy(
+                                forespurtData = expectedForespurtData,
+                            )
+
+                    val actualForespoersler =
+                        forespoerselDao.hentForespoerslerEksponertTilSimba(setOf(expectedForespoersel.vedtaksperiodeId))
+
+                    actualForespoersler shouldHaveSize 1
+                    actualForespoersler.first() shouldBe expectedForespoersel
+                }
+            }
+
+            test("tåler ingen forespørsler") {
+                val forespoerslerEksponertTilSimba =
+                    forespoerselDao.hentForespoerslerEksponertTilSimba(setOf(MockUuid.vedtaksperiodeId))
+
+                forespoerslerEksponertTilSimba.shouldBeEmpty()
+            }
+
+            test("tåler ingen ønskede forespørsler") {
+                val idA = mockForespoerselDto().lagreEksponertNotNull()
+
+                db.oppdaterStatus(idA, Status.FORKASTET)
+
+                val forespoerslerEksponertTilSimba =
+                    forespoerselDao.hentForespoerslerEksponertTilSimba(setOf(MockUuid.vedtaksperiodeId))
+
+                forespoerslerEksponertTilSimba.shouldBeEmpty()
             }
         }
 
@@ -1209,3 +1416,13 @@ private fun tilForespoerselMedEksponertId(row: ResultRow): Pair<UUID, Forespoers
 private fun ForespoerselDto.oekOpprettet(sekunder: Long): ForespoerselDto = copy(opprettet = opprettet.plusSeconds(sekunder))
 
 private fun now(): LocalDateTime = LocalDateTime.now().truncMillis()
+
+private fun List<Pair<Status, Set<SpleisForespurtDataDto>>>.tilForespoersler(): List<ForespoerselDto> =
+    mapIndexed { index, (status, forespurtData) ->
+        mockForespoerselDto()
+            .oekOpprettet(index.toLong())
+            .copy(
+                status = status,
+                forespurtData = forespurtData,
+            )
+    }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDtoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/ForespoerselDtoTest.kt
@@ -52,7 +52,7 @@ class ForespoerselDtoTest :
                     },
                     "Oppdager ulik 'forespurtData'" to {
                         it.copy(
-                            forespurtData = listOf(SpleisInntekt),
+                            forespurtData = setOf(SpleisInntekt),
                         )
                     },
                 ),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/SpleisForespurtDataDtoTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/domene/SpleisForespurtDataDtoTest.kt
@@ -6,7 +6,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.bro.sykepenger.testutils.mockSpleisForespurtDataListe
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.parseJson
-import no.nav.helsearbeidsgiver.utils.json.serializer.list
+import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
 import no.nav.helsearbeidsgiver.utils.test.resource.readResource
@@ -18,7 +18,7 @@ class SpleisForespurtDataDtoTest :
         test("Forespurt data serialiseres korrekt") {
             val forespurtDataListe = mockSpleisForespurtDataListe()
 
-            val serialisertJson = forespurtDataListe.toJsonStr(SpleisForespurtDataDto.serializer().list())
+            val serialisertJson = forespurtDataListe.toJsonStr(SpleisForespurtDataDto.serializer().set())
 
             serialisertJson shouldBe expectedJson
         }
@@ -26,7 +26,7 @@ class SpleisForespurtDataDtoTest :
         test("Forespurt data deserialiseres korrekt") {
             val forespurtDataListe = mockSpleisForespurtDataListe()
 
-            val deserialisertJson = expectedJson.parseJson().fromJson(SpleisForespurtDataDto.serializer().list())
+            val deserialisertJson = expectedJson.parseJson().fromJson(SpleisForespurtDataDto.serializer().set())
 
             deserialisertJson shouldContainExactly forespurtDataListe
         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/testutils/MockUtils.kt
@@ -55,8 +55,8 @@ fun mockForespoerselDto(): ForespoerselDto {
     )
 }
 
-fun mockSpleisForespurtDataListe(): List<SpleisForespurtDataDto> =
-    listOf(
+fun mockSpleisForespurtDataListe(): Set<SpleisForespurtDataDto> =
+    setOf(
         SpleisArbeidsgiverperiode,
         SpleisInntekt,
         SpleisRefusjon,


### PR DESCRIPTION
Dette er et steg på veien til å kunne kreve at arbeidsgiver kun kan sende inntektsmelding på nyeste forespørsel. Vi må da la dem sende inn endringer på data vi tidligere har forespurt, men som ikke bes om i nyeste forespørsel. Merk at vi bare ivaretar historikk fra besvarte forespørsler, og at forkastede ignoreres.