### PR TITLE
logg info hvis man ikke finner noen fsp ved synk

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/HentForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/HentForespoerselRiver.kt
@@ -62,7 +62,7 @@ class HentForespoerselRiver(
         }
         val forespoerselListe = forespoerselDao.hentForespoerslerForVedtaksperiodeIdListe(setOf(vedtaksperiodeId))
         if (forespoerselListe.isEmpty()) {
-            logger().error("Det er ingen forespørsel for vedtaksperiodeId=$vedtaksperiodeId.")
+            logger().info("Det er ingen forespørsel for vedtaksperiodeId=$vedtaksperiodeId.")
             return
         } else {
             logger().info("Fant ${forespoerselListe.size} forespørsel(er) for vedtaksperiodeId=$vedtaksperiodeId.")


### PR DESCRIPTION
Logg info hvis man ikke finner noen fsp ved synk kall til lps api  - dette er forventet oppførsel.
Kan på sikt endre til å ta imot liste av vedtaksperiodeider i riveren. Da vil ikke dette skje lenger 