### PR TITLE
Bruk Java 25

### DIFF
--- a/.github/workflows/build-and-deploy-dev.yml
+++ b/.github/workflows/build-and-deploy-dev.yml
@@ -15,5 +15,6 @@ jobs:
       nais-manifest: deploy/nais.yml
       nais-manifest-vars: deploy/dev.yml
       project-id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+      java-version: 25
     secrets:
       identity-provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -14,5 +14,6 @@ jobs:
       nais-manifest: deploy/nais.yml
       nais-manifest-vars: deploy/prod.yml
       project-id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+      java-version: 25
     secrets:
       identity-provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -17,3 +17,5 @@ jobs:
     uses: navikt/hag-workflows/.github/workflows/dependency-submission.yml@main
     permissions:
       contents: write
+    with:
+      java-version: 25

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java21
+FROM gcr.io/distroless/java25
 COPY build/libs/*.jar ./
 ENV JAVA_OPTS='-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'
 ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 val mainClassPath = "no.nav.helsearbeidsgiver.bro.sykepenger.AppKt"
 
 plugins {
@@ -15,9 +13,7 @@ application {
 }
 
 kotlin {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
-    }
+    jvmToolchain(25)
 }
 
 tasks {


### PR DESCRIPTION
Java 25 er siste LTS-versjon. Den ble sluppet i september 2025, så vi skal bør kunne bytte over uten å få noen bleeding edge overraskelser.