### PR TITLE
Bugfix: Trigg LPS-API til å oppdatere / synkronisere fsp når vi får forkastet-melding

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/ForkastForespoerselRiver.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/ForkastForespoerselRiver.kt
@@ -80,8 +80,14 @@ internal class ForkastForespoerselRiver(
                 Pri.Key.SENDT_TID to LocalDateTime.now().truncMillis().toJson(),
                 Pri.Key.FORESPOERSEL_ID to forespoersel.forespoerselId.toJson(),
             )
-
             loggernaut.info("Sa ifra om forkastet forespørsel til Simba.")
+
+            priProducer.send(
+                forespoersel.vedtaksperiodeId,
+                Pri.Key.BEHOV to Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID.toJson(Pri.BehovType.serializer()),
+                Pri.Key.VEDTAKSPERIODE_ID to vedtaksperiodeId.toJson(),
+            )
+            loggernaut.info("Trigget synkronisering av forespørsler for LPS-API for vedtaksperiodeId: $vedtaksperiodeId")
         }
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/ForkastForespoerselRiverTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/bro/sykepenger/ForkastForespoerselRiverTest.kt
@@ -52,7 +52,7 @@ class ForkastForespoerselRiverTest :
             }
         }
 
-        test("Sier ifra til Simba om at forespørsel er forkastet") {
+        test("Sier ifra til Simba om at forespørsel er forkastet og trigger LPS-API synkronisering") {
             val forespoersel = mockForespoerselDto()
             val utesendingstidspunkt = LocalDateTime.of(2024, 6, 1, 12, 0)
             mockStatic(LocalDateTime::class) {
@@ -70,6 +70,11 @@ class ForkastForespoerselRiverTest :
                         Pri.Key.NOTIS to Pri.NotisType.FORESPOERSEL_FORKASTET.toJson(Pri.NotisType.serializer()),
                         Pri.Key.SENDT_TID to utesendingstidspunkt.toJson(),
                         Pri.Key.FORESPOERSEL_ID to forespoersel.forespoerselId.toJson(),
+                    )
+                    mockPriProducer.send(
+                        vedtaksperiodeId,
+                        Pri.Key.BEHOV to Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID.toJson(Pri.BehovType.serializer()),
+                        Pri.Key.VEDTAKSPERIODE_ID to vedtaksperiodeId.toJson(),
                     )
                 }
             }


### PR DESCRIPTION
Forespørsel forkastet: 
Bro forkaster alle forespørsler på vedtaksperiodeID, men sendte kun forkastet-melding på eksponert forespørsel videre. 
Dette gjorde at dersom vi hadde flere forespørsler på en periode, ble bare eksponertFSP satt til forkastet i LPS-API. 
Workaround/Bugfix: Trigger synkronisering slik at LPS-API også oppdaterer øvrige forespørsler.

På sikt skal jeg se på om kanskje LPS-API heller skal trigge synkroniseringsmeldingen selv når den får "forkastet"-beskjeden (og andre meldinger fra Bro), men foreløpig hekter jeg det bare på i bro-flyten. 

